### PR TITLE
Fix TypeScript build errors and add typography improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/styled": "^11.14.1",
         "@fontsource/inter": "^5.2.6",
         "@fontsource/roboto": "^5.2.6",
+        "@fontsource/space-grotesk": "^5.2.8",
         "@hookform/resolvers": "^5.2.1",
         "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
@@ -1963,6 +1964,14 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.6.tgz",
       "integrity": "sha512-hzarG7yAhMoP418smNgfY4fO7UmuUEm5JUtbxCoCcFHT0hOJB+d/qAEyoNjz7YkPU5OjM2LM8rJnW8hfm0JLaA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.8.tgz",
+      "integrity": "sha512-8rlIzpX+lo36y0g77OlwjeBj2DPo9XOwrzqKRLHYZcWcsj73SlkVI6UdXxDCZGLO7oQti1q9QPXzMBYbzSz60w==",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@emotion/styled": "^11.14.1",
     "@fontsource/inter": "^5.2.6",
     "@fontsource/roboto": "^5.2.6",
+    "@fontsource/space-grotesk": "^5.2.8",
     "@hookform/resolvers": "^5.2.1",
     "@mui/icons-material": "^7.3.1",
     "@mui/material": "^7.3.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Roboto } from 'next/font/google';
+import { Roboto, Space_Grotesk } from 'next/font/google';
 
 import { ClientThemeProvider } from '@/components/ClientThemeProvider';
 import { Footer } from '@/components/Footer';
@@ -10,12 +10,22 @@ import '@fontsource/inter/300.css';
 import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
 import '@fontsource/inter/700.css';
+import '@fontsource/space-grotesk/300.css';
+import '@fontsource/space-grotesk/400.css';
+import '@fontsource/space-grotesk/500.css';
+import '@fontsource/space-grotesk/700.css';
 import './globals.css';
 
 const roboto = Roboto({
   weight: ['300', '400', '500', '700'],
   subsets: ['latin'],
   variable: '--font-roboto',
+});
+
+const spaceGrotesk = Space_Grotesk({
+  weight: ['300', '400', '500', '700'],
+  subsets: ['latin'],
+  variable: '--font-space-grotesk',
 });
 
 export const metadata: Metadata = {
@@ -31,7 +41,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={roboto.variable}>
+      <body className={`${roboto.variable} ${spaceGrotesk.variable}`}>
         <NextAuthSessionProvider>
           <ClientThemeProvider>
             <Header />

--- a/src/components/Wordmark.tsx
+++ b/src/components/Wordmark.tsx
@@ -30,6 +30,7 @@ export function Wordmark({
         variant={sizeMap[size]}
         component="span"
         sx={{
+          fontFamily: 'var(--font-space-grotesk)',
           fontWeight: 700,
           color: colorMap[color],
           letterSpacing: '-0.02em',
@@ -42,6 +43,7 @@ export function Wordmark({
         variant={sizeMap[size]}
         component="span"
         sx={{
+          fontFamily: 'var(--font-space-grotesk)',
           fontWeight: 400,
           color: colorMap[color],
           letterSpacing: '-0.02em',


### PR DESCRIPTION
## Summary
• **TypeScript fixes**: Resolve build errors with proper type safety for house color generation and React hooks dependencies
• **Typography improvements**: Add Space Grotesk font specifically for wordmark to create modern, geometric branding  
• **Mobile UX enhancements**: Improve house spacing on mobile devices for better visual balance

## Changes Made
### TypeScript & Build Fixes
- Add proper type safety for house color generation with fallback values
- Wrap `getHousePositions` in `useCallback` with correct dependencies
- Fix React hooks exhaustive-deps warnings
- Add missing `brandColors` import

### Typography Enhancements  
- Install and configure Space Grotesk font family
- Apply Space Grotesk specifically to wordmark components only
- Keep body text using existing fonts for optimal readability
- Add CSS variables for font family management

### Mobile UX Improvements
- Improve house spacing on mobile: positioned at 20% and 80% instead of 33% and 67%
- Standardize all house icons to use consistent house5.svg design
- Add color assignment system for potential future design variations

## Test Plan
- [x] Verify TypeScript build passes without errors
- [x] Test wordmark displays with Space Grotesk font correctly  
- [x] Confirm mobile house spacing looks balanced on small screens
- [x] Check animation performance remains smooth across devices
- [x] Validate lint and pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)