### PR TITLE
Fix magic link redirects for production invitations

### DIFF
--- a/src/app/api/borrow-requests/route.ts
+++ b/src/app/api/borrow-requests/route.ts
@@ -232,7 +232,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Create approval URL
-    const approvalUrl = `${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/borrow-approval/${responseToken}`;
+    const approvalUrl = `${process.env.NEXTAUTH_URL}/borrow-approval/${responseToken}`;
 
     // Send SMS notification to owner
     try {

--- a/src/app/api/branches/[id]/invite/route.ts
+++ b/src/app/api/branches/[id]/invite/route.ts
@@ -154,7 +154,7 @@ export async function POST(
 
     // Send invitation email
     try {
-      const magicLink = `${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/invitations/${token}`;
+      const magicLink = `${process.env.NEXTAUTH_URL}/api/invitations/${token}`;
 
       const resend = new Resend(process.env.RESEND_API_KEY);
       await resend.emails.send({

--- a/src/app/api/invitations/[token]/route.ts
+++ b/src/app/api/invitations/[token]/route.ts
@@ -1,5 +1,4 @@
-import { redirect } from 'next/navigation';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { db } from '@/lib/db';
 
@@ -12,7 +11,9 @@ export async function GET(
     // token already extracted above
 
     if (!token || typeof token !== 'string') {
-      return redirect('/auth/error?error=invalid_invitation');
+      return NextResponse.redirect(
+        new URL('/auth/error?error=invalid_invitation', request.url)
+      );
     }
 
     // Find and validate invitation
@@ -38,7 +39,9 @@ export async function GET(
     });
 
     if (!invitation) {
-      return redirect('/auth/error?error=invitation_not_found');
+      return NextResponse.redirect(
+        new URL('/auth/error?error=invitation_not_found', request.url)
+      );
     }
 
     // Check if invitation has expired
@@ -49,7 +52,9 @@ export async function GET(
         data: { status: 'EXPIRED' },
       });
 
-      return redirect('/auth/error?error=invitation_expired');
+      return NextResponse.redirect(
+        new URL('/auth/error?error=invitation_expired', request.url)
+      );
     }
 
     // Check if user already exists and is already a member
@@ -69,7 +74,12 @@ export async function GET(
       existingUser?.branchMemberships &&
       existingUser.branchMemberships.length > 0
     ) {
-      return redirect(`/branch/${invitation.branchId}?message=already_member`);
+      return NextResponse.redirect(
+        new URL(
+          `/branch/${invitation.branchId}?message=already_member`,
+          request.url
+        )
+      );
     }
 
     // Store invitation token in URL for the auth callback to process
@@ -77,9 +87,11 @@ export async function GET(
 
     // For magic link authentication, we redirect to NextAuth callback
     // The callback will handle creating/logging in the user and processing the invitation
-    return redirect(callbackUrl);
+    return NextResponse.redirect(new URL(callbackUrl, request.url));
   } catch (error) {
     console.error('Error processing invitation link:', error);
-    return redirect('/auth/error?error=invitation_processing_failed');
+    return NextResponse.redirect(
+      new URL('/auth/error?error=invitation_processing_failed', request.url)
+    );
   }
 }


### PR DESCRIPTION
## Summary
- 🐛 **Fix Magic Link Redirects**: Resolve `NEXT_REDIRECT` errors preventing invitation acceptance
- 🌐 **Production URL Generation**: Remove localhost fallbacks in invitation and borrow approval emails
- ✅ **API Route Compatibility**: Use proper `NextResponse.redirect()` instead of `redirect()` in API routes

## Bug Fixes

### Magic Link Redirect Error
**Problem**: Users clicking invitation magic links were getting `invitation_processing_failed` errors due to `NEXT_REDIRECT` exceptions in API routes.

**Root Cause**: Using `redirect()` from `next/navigation` in API routes throws an error, even though the redirect works.

**Solution**: Replace all `redirect()` calls with `NextResponse.redirect(new URL(...))` in `/api/invitations/[token]/route.ts`

### Production URL Generation  
**Problem**: Invitation and borrow approval emails were using localhost URLs even in production due to fallback logic.

**Root Cause**: Code was using `process.env.NEXTAUTH_URL || 'http://localhost:3000'` which defaulted to localhost when env var was misconfigured.

**Solution**: Remove localhost fallback and rely on properly configured `NEXTAUTH_URL` environment variable.

## Files Changed
- `src/app/api/invitations/[token]/route.ts`: Fix redirect handling in magic link processing
- `src/app/api/branches/[id]/invite/route.ts`: Remove localhost fallback from invitation emails  
- `src/app/api/borrow-requests/route.ts`: Remove localhost fallback from borrow approval emails

## Technical Details

### Before (Broken)
```javascript
import { redirect } from 'next/navigation';
// In API route:
return redirect('/auth/callback?invitation=token'); // Throws NEXT_REDIRECT error
```

### After (Fixed) 
```javascript
import { NextResponse } from 'next/server';
// In API route:
return NextResponse.redirect(new URL('/auth/callback?invitation=token', request.url));
```

## Test Plan
- [ ] Send invitation from production environment
- [ ] Verify invitation email contains correct production URL (not localhost)
- [ ] Click magic link and confirm no `invitation_processing_failed` error
- [ ] Verify successful redirect to auth callback flow
- [ ] Test complete invitation → profile creation → branch joining flow
- [ ] Test borrow request approval links also use correct URLs

## Impact
This fixes the critical blocker preventing users from accepting branch invitations in production. The complete social sharing workflow (invite → join → borrow) should now work end-to-end.

🤖 Generated with [Claude Code](https://claude.ai/code)