### PR TITLE
Improve existing member magic link flow with personalized welcome banner

### DIFF
--- a/src/app/api/invitations/[token]/accept/route.ts
+++ b/src/app/api/invitations/[token]/accept/route.ts
@@ -133,6 +133,13 @@ export async function POST(
       }),
     ]);
 
+    // Get user's name for welcome banner
+    const userDetails = await db.user.findUnique({
+      where: { id: userId },
+      select: { name: true },
+    });
+    const firstName = userDetails?.name?.split(' ')[0] || '';
+
     return NextResponse.json({
       success: true,
       branch: {
@@ -140,6 +147,9 @@ export async function POST(
         name: invitation.branch!.name,
         location: invitation.branch!.location,
         role: branchMember.role,
+      },
+      user: {
+        firstName,
       },
     });
   } catch (error) {

--- a/src/app/api/invitations/[token]/route.ts
+++ b/src/app/api/invitations/[token]/route.ts
@@ -57,7 +57,7 @@ export async function GET(
       );
     }
 
-    // Check if user already exists and is already a member
+    // Check if user already exists and is already a member of THIS SPECIFIC branch
     const existingUser = await db.user.findFirst({
       where: { email: invitation.email },
       include: {
@@ -70,6 +70,7 @@ export async function GET(
       },
     });
 
+    // Only redirect if they're already a member of THIS specific branch
     if (
       existingUser?.branchMemberships &&
       existingUser.branchMemberships.length > 0

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -42,7 +42,21 @@ export default async function AuthCallbackPage({
     const branchId = params.branch as string;
 
     if (user.profileCompleted) {
-      redirect(`/branch/${branchId}?message=joined_successfully`);
+      // Get user's first name for welcome banner
+      const fullUser = await db.user.findUnique({
+        where: { id: user.id },
+        select: { name: true },
+      });
+      const firstName = fullUser?.name?.split(' ')[0] || '';
+      const welcomeUrl = new URL(
+        `/branch/${branchId}`,
+        'http://localhost:3000'
+      );
+      welcomeUrl.searchParams.set('message', 'joined_successfully');
+      if (firstName) {
+        welcomeUrl.searchParams.set('welcomeName', firstName);
+      }
+      redirect(welcomeUrl.toString().replace('http://localhost:3000', ''));
     } else {
       redirect(
         `/profile/create?invitation=${invitationToken}&branch=${branchId}`

--- a/src/components/BranchDetailClient.tsx
+++ b/src/components/BranchDetailClient.tsx
@@ -29,7 +29,7 @@ import {
   Paper,
 } from '@mui/material';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { brandColors } from '@/theme/brandTokens';
@@ -118,6 +118,7 @@ const CATEGORY_CONFIG = {
 
 export function BranchDetailClient({ branchId }: BranchDetailClientProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [branch, setBranch] = useState<BranchData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -125,6 +126,8 @@ export function BranchDetailClient({ branchId }: BranchDetailClientProps) {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
   const [inviteModalOpen, setInviteModalOpen] = useState(false);
+  const [showWelcomeBanner, setShowWelcomeBanner] = useState(false);
+  const [currentUserName, setCurrentUserName] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchBranch = async () => {
@@ -148,6 +151,24 @@ export function BranchDetailClient({ branchId }: BranchDetailClientProps) {
 
     fetchBranch();
   }, [branchId]);
+
+  // Handle welcome banner for new members
+  useEffect(() => {
+    const message = searchParams.get('message');
+    if (message === 'joined_successfully') {
+      const welcomeName = searchParams.get('welcomeName');
+      if (welcomeName) {
+        setCurrentUserName(welcomeName);
+      }
+      setShowWelcomeBanner(true);
+
+      // Clear the message parameters from URL without page reload
+      const newUrl = new URL(window.location.href);
+      newUrl.searchParams.delete('message');
+      newUrl.searchParams.delete('welcomeName');
+      window.history.replaceState({}, '', newUrl.toString());
+    }
+  }, [searchParams]);
 
   const handleNotifyWhenReturned = async (itemId: string) => {
     // TODO: Implement notification queue API
@@ -295,6 +316,43 @@ export function BranchDetailClient({ branchId }: BranchDetailClientProps) {
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Welcome Banner for New Members */}
+      {showWelcomeBanner && (
+        <Alert
+          severity="success"
+          action={
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              size="small"
+              onClick={() => setShowWelcomeBanner(false)}
+            >
+              <CloseIcon fontSize="inherit" />
+            </IconButton>
+          }
+          sx={{
+            mb: 4,
+            bgcolor: '#f0f9ff',
+            border: '1px solid #3b82f6',
+            borderRadius: 2,
+            '& .MuiAlert-icon': {
+              color: '#3b82f6',
+            },
+            '& .MuiAlert-message': {
+              color: '#1e40af',
+              fontSize: '1rem',
+              fontWeight: 500,
+            },
+            '& .MuiAlert-action': {
+              color: '#3b82f6',
+            },
+          }}
+        >
+          Welcome{currentUserName ? `, ${currentUserName}` : ''}, to{' '}
+          {branch.name}! 🎉
+        </Alert>
+      )}
+
       {/* Header */}
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 4 }}>
         <IconButton

--- a/src/components/InvitedBranchesSection.tsx
+++ b/src/components/InvitedBranchesSection.tsx
@@ -85,8 +85,16 @@ export function InvitedBranchesSection() {
         // Remove the accepted invitation from the list
         setInvitations((prev) => prev.filter((inv) => inv.token !== token));
 
-        // Redirect to the branch page
-        window.location.href = `/branch/${data.branch.id}?message=joined_successfully`;
+        // Redirect to the branch page with welcome banner
+        const redirectUrl = new URL(
+          `/branch/${data.branch.id}`,
+          window.location.origin
+        );
+        redirectUrl.searchParams.set('message', 'joined_successfully');
+        if (data.user?.firstName) {
+          redirectUrl.searchParams.set('welcomeName', data.user.firstName);
+        }
+        window.location.href = redirectUrl.toString();
       } else {
         const errorData = await response.json();
         setError(errorData.error || 'Failed to join branch');


### PR DESCRIPTION
## Summary
- Enhance magic link flow for existing members joining new branches
- Add personalized welcome banner that shows once: "Welcome, {firstName}, to {branchName}! 🎉"
- Bypass profile creation flow for members with completed profiles
- Clean URL parameters automatically after banner display

## Changes Made
- **Enhanced Auth Callback**: Pass user's first name via URL parameter for personalization
- **Welcome Banner Component**: Detect join success and show dismissible welcome banner
- **Updated Invitation API**: Return user's first name to support both magic link and manual flows
- **Clean URL Handling**: Remove tracking parameters after banner display

## Test Plan
- [x] TypeScript compilation passes
- [ ] Test magic link flow for existing member joining new branch
- [ ] Verify welcome banner shows with correct personalization
- [ ] Confirm banner is dismissible and appears only once
- [ ] Test fallback when first name unavailable
- [ ] Verify URL parameters are cleaned after display

## User Experience
**Before:** Existing member clicks magic link → generic branch page experience
**After:** Existing member clicks magic link → personalized welcome banner with their name

🤖 Generated with [Claude Code](https://claude.ai/code)