### PR TITLE
fix: resolve item creation issues and implement square photo cropping

### DIFF
--- a/src/app/api/items/route.ts
+++ b/src/app/api/items/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
         imageUrl: imageUrl,
         isAvailable: true,
         ownerId: userId,
-        branchId: branchId,
+        ...(branchId && { branchId }),
         stuffTypeId: stuffType.id,
       },
       include: {

--- a/src/components/AddItemClient.tsx
+++ b/src/components/AddItemClient.tsx
@@ -148,20 +148,53 @@ export function AddItemClient({ branchId }: AddItemClientProps) {
 
     if (!ctx) return;
 
-    // Set canvas size to match video
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
+    // Calculate the viewfinder area (center 80% of video, matching the overlay)
+    const margin = 0.1; // 10% margin on all sides
+    const cropWidth = video.videoWidth * (1 - 2 * margin);
+    const cropHeight = video.videoHeight * (1 - 2 * margin);
+
+    // Make the crop area square by using the smaller dimension
+    const cropSize = Math.min(cropWidth, cropHeight);
+    const centerX = video.videoWidth / 2;
+    const centerY = video.videoHeight / 2;
+    const squareCropX = centerX - cropSize / 2;
+    const squareCropY = centerY - cropSize / 2;
+
+    // Set canvas size to square crop area
+    canvas.width = cropSize;
+    canvas.height = cropSize;
 
     console.log('📷 Canvas size:', canvas.width, 'x', canvas.height);
     console.log('📹 Video size:', video.videoWidth, 'x', video.videoHeight);
+    console.log('✂️ Crop area:', squareCropX, squareCropY, cropSize, cropSize);
 
-    // Draw video frame to canvas (flip horizontally if mirrored in preview)
+    // Draw cropped video frame to canvas (flip horizontally if mirrored in preview)
     if (shouldMirrorCamera) {
       ctx.scale(-1, 1);
-      ctx.drawImage(video, -canvas.width, 0);
+      ctx.drawImage(
+        video,
+        squareCropX,
+        squareCropY,
+        cropSize,
+        cropSize,
+        -cropSize,
+        0,
+        cropSize,
+        cropSize
+      );
       ctx.scale(-1, 1); // Reset the scale
     } else {
-      ctx.drawImage(video, 0, 0);
+      ctx.drawImage(
+        video,
+        squareCropX,
+        squareCropY,
+        cropSize,
+        cropSize,
+        0,
+        0,
+        cropSize,
+        cropSize
+      );
     }
 
     console.log('🎨 Canvas drawn, checking image data...');


### PR DESCRIPTION
## Summary
🐛 Fixed critical bugs preventing item creation via camera capture
📷 Implemented proper square photo cropping to match viewfinder display
✅ Users now get exactly what they see in the camera viewfinder, not extra content

## Issues Fixed

### 🚨 Database Constraint Violation
**Problem**: `P2011 Prisma constraint violation on branchId field`
- API was passing `null` for branchId even though it's optional in schema
- Caused 500 error preventing any item creation

**Solution**: 
- Use conditional object spread `...(branchId && { branchId })` 
- Only include branchId field when it has a truthy value
- Allows items to be created without library assignment

### 📱 Camera Capture Mismatch  
**Problem**: Camera preview shows square viewfinder but saves full vertical image
- Users saw square crop area with overlay guidance
- Actual saved image included content outside viewfinder bounds
- Confusing UX - "what you see ≠ what you get"

**Solution**:
- Calculate exact crop area matching 10% margin overlay
- Convert rectangular video frame to square crop centered on viewfinder
- Canvas now crops to `center square (80% of video frame)`
- Handles both normal and mirrored camera modes correctly

## Technical Details

### API Enhancement
```typescript
// Before: Always passed branchId (could be null)
branchId: branchId,

// After: Conditionally include only when present  
...(branchId && { branchId }),
```

### Camera Cropping Logic
```typescript
// Calculate viewfinder area (center 80% of video)
const margin = 0.1; // 10% margin on all sides
const cropWidth = video.videoWidth * (1 - 2 * margin);
const cropHeight = video.videoHeight * (1 - 2 * margin);

// Make square using smaller dimension
const cropSize = Math.min(cropWidth, cropHeight);
const centerX = video.videoWidth / 2;
const centerY = video.videoHeight / 2;
const squareCropX = centerX - cropSize / 2;
const squareCropY = centerY - cropSize / 2;

// Crop canvas to match viewfinder exactly
canvas.width = cropSize;
canvas.height = cropSize;
```

## Testing
- ✅ **Build**: Clean compilation with no errors
- ✅ **TypeScript**: All types validate correctly
- ✅ **Linting**: Passes with only pre-existing warnings
- 🧪 **Manual testing**: Ready for item creation flow validation

## User Impact
- **Item creation now works** - no more 500 errors
- **Predictable photo cropping** - users get exactly what they frame
- **Better mobile experience** - proper square format for recognition
- **No breaking changes** - existing items and functionality unchanged

This fix resolves the core item addition workflow and significantly improves the camera capture UX.

🤖 Generated with [Claude Code](https://claude.ai/code)