### PR TITLE
🔧 Database migration: make branchId optional to fix production item creation

### DIFF
--- a/prisma/migrations/20250827235600_make_branchid_optional_add_location/migration.sql
+++ b/prisma/migrations/20250827235600_make_branchid_optional_add_location/migration.sql
@@ -1,4 +1,5 @@
--- AlterTable ALTER TABLE "public"."items" 
+-- AlterTable
+ALTER TABLE "public"."items" 
 ADD COLUMN IF NOT EXISTS "location" TEXT,
 ALTER COLUMN "branchId" DROP NOT NULL;
 


### PR DESCRIPTION
## 🚨 **Critical Fix for Production Issue**

This PR contains the essential database migration to resolve the production item creation failure.

## 🐛 **Issue**
Production is failing to create items with this error:
```
Invalid `prisma.item.create()` invocation:
Null constraint violation on the fields: (`branchId`)
Error [PrismaClientKnownRequestError]: code: 'P2011'
```

## 🔧 **Root Cause**
- The recent code changes (merged in #136) allow items to be created without library assignment
- However, the production database still has `branchId` as a **required field** (NOT NULL constraint)
- This creates a mismatch between the code expectations and database schema

## 🛠️ **Solution**
Created migration `20250827235600_make_branchid_optional_add_location` that:

### Database Changes:
1. **Makes `branchId` nullable**: `ALTER COLUMN "branchId" DROP NOT NULL`
2. **Adds `location` field**: `ADD COLUMN "location" TEXT`  
3. **Updates foreign key constraint**: Uses `ON DELETE SET NULL` for proper cleanup

### Migration SQL:
```sql
ALTER TABLE "public"."items" 
ADD COLUMN IF NOT EXISTS "location" TEXT,
ALTER COLUMN "branchId" DROP NOT NULL;

ALTER TABLE "public"."items" DROP CONSTRAINT IF EXISTS "items_branchId_fkey";
ALTER TABLE "public"."items" ADD CONSTRAINT "items_branchId_fkey" 
FOREIGN KEY ("branchId") REFERENCES "public"."branches"("id") ON DELETE SET NULL;
```

## ✅ **Expected Result**
After deployment:
- ✅ **Item creation works** - users can create items without library assignment
- ✅ **No data loss** - existing items and relationships remain intact  
- ✅ **Backward compatible** - items can still be assigned to libraries when desired
- ✅ **Proper cleanup** - when libraries are deleted, items become unassigned (not deleted)

## 🚀 **Deployment**
This migration will run automatically when deployed to production via:
```bash
npx prisma migrate deploy
```

## ⚠️ **Priority**
This is a **critical fix** - production item creation is completely broken without this migration.

🤖 Generated with [Claude Code](https://claude.ai/code)