### PR TITLE
🔧 Fix OpenAI JSON parsing: handle markdown code blocks

### DIFF
--- a/src/app/api/analyze-item/route.ts
+++ b/src/app/api/analyze-item/route.ts
@@ -16,6 +16,24 @@ function getOpenAIClient() {
   });
 }
 
+function cleanJsonResponse(content: string): string {
+  // Remove markdown code blocks if present
+  let cleaned = content.trim();
+
+  // Remove ```json at start and ``` at end
+  if (cleaned.startsWith('```json')) {
+    cleaned = cleaned.replace(/^```json\s*/, '');
+  }
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```\s*/, '');
+  }
+  if (cleaned.endsWith('```')) {
+    cleaned = cleaned.replace(/\s*```$/, '');
+  }
+
+  return cleaned.trim();
+}
+
 export async function POST(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
@@ -85,7 +103,8 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      const result = JSON.parse(content);
+      const cleanedContent = cleanJsonResponse(content);
+      const result = JSON.parse(cleanedContent);
 
       // Validate the response structure
       if (
@@ -100,6 +119,7 @@ export async function POST(request: NextRequest) {
     } catch (parseError) {
       console.error('Error parsing AI response:', parseError);
       console.error('Raw response:', content);
+      console.error('Cleaned response:', cleanJsonResponse(content));
 
       return NextResponse.json({
         recognized: false,


### PR DESCRIPTION
## 🚨 **Production Issue Fixed**

After the successful database migration, we encountered a new error in the item analysis flow.

## 🐛 **The Issue**
OpenAI was returning JSON responses wrapped in markdown code blocks:
```
```json
{
  "name": "Hammer",
  "recognized": true,
  "confidence": 0.95,
  "category": "tools"
}
```
```

But our code was trying to parse this directly with `JSON.parse()`, causing:
```
Error parsing AI response: SyntaxError: Unexpected token '`'
```

## ✅ **The Fix**
Added a `cleanJsonResponse()` function that:

### 🧹 **Cleaning Logic**
- Strips ````json` from the beginning of responses
- Strips ````` from the beginning if present  
- Strips ````` from the end if present
- Handles both raw JSON and markdown-wrapped JSON

### 🔍 **Better Error Logging**
- Logs both raw response and cleaned response
- Helps debug future parsing issues
- Shows exactly what OpenAI returned vs what we tried to parse

## 🧪 **Testing**
- ✅ Build passes cleanly
- ✅ Handles both response formats:
  - Raw JSON: `{"name": "Hammer", ...}`  
  - Markdown wrapped: ` ```json\n{"name": "Hammer", ...}\n``` `

## 🎯 **Result**
Item image analysis will now work reliably regardless of how OpenAI formats the response. Users can successfully:
- Take photos of items ✅  
- Get AI-powered item recognition ✅
- Complete the item creation flow ✅

This resolves the JSON parsing errors in the analyze-item endpoint and ensures smooth item creation after photo capture.

🤖 Generated with [Claude Code](https://claude.ai/code)