### PR TITLE
Fix: Resolve duplicate borrow request notifications and standardize links

### DIFF
--- a/src/lib/enhanced-notification-service.ts
+++ b/src/lib/enhanced-notification-service.ts
@@ -89,7 +89,7 @@ export async function sendBorrowRequestReceivedNotification(
     }
 
     // Create single notification that handles both in-app and email
-    const notificationPromise = createNotification({
+    const notificationData: any = {
       userId: borrowRequest.lenderId,
       type: 'BORROW_REQUEST_RECEIVED' as NotificationType,
       title: 'New Borrow Request',
@@ -97,15 +97,21 @@ export async function sendBorrowRequestReceivedNotification(
       actionUrl: `/borrow-approval/${borrowRequest.id}`,
       relatedItemId: borrowRequest.itemId,
       relatedRequestId: borrowRequest.id,
-      sendEmail: !!emailTemplate,
-      emailTemplate,
       metadata: {
         borrowerName: borrowRequest.borrower.name,
         itemName: borrowRequest.item.name,
         requestMessage: borrowRequest.requestMessage,
         videoUrl: borrowRequest.videoUrl,
       },
-    });
+    };
+
+    // Only add email properties if template exists
+    if (emailTemplate) {
+      notificationData.sendEmail = true;
+      notificationData.emailTemplate = emailTemplate;
+    }
+
+    const notificationPromise = createNotification(notificationData);
 
     // Legacy SMS notification for backward compatibility
     const legacyNotificationData: Parameters<

--- a/src/lib/enhanced-notification-service.ts
+++ b/src/lib/enhanced-notification-service.ts
@@ -51,25 +51,10 @@ export async function sendBorrowRequestReceivedNotification(
   approvalUrl: string
 ) {
   try {
-    // Create in-app notification
-    const notificationPromise = createNotification({
-      userId: borrowRequest.lenderId,
-      type: 'BORROW_REQUEST_RECEIVED' as NotificationType,
-      title: 'New Borrow Request',
-      message: `${borrowRequest.borrower.name} wants to borrow your "${borrowRequest.item.name}"`,
-      actionUrl: `/lender/requests/${borrowRequest.id}`,
-      relatedItemId: borrowRequest.itemId,
-      relatedRequestId: borrowRequest.id,
-      metadata: {
-        borrowerName: borrowRequest.borrower.name,
-        itemName: borrowRequest.item.name,
-        requestMessage: borrowRequest.requestMessage,
-        videoUrl: borrowRequest.videoUrl,
-      },
-    });
-
-    // Send email with rich template
-    let emailPromise: Promise<any> | undefined;
+    // Prepare email template if email is available
+    let emailTemplate:
+      | { subject: string; html: string; to: string }
+      | undefined;
     if (borrowRequest.lender.email) {
       const templateProps: Parameters<
         typeof EmailTemplates.borrowRequestReceived
@@ -95,21 +80,32 @@ export async function sendBorrowRequestReceivedNotification(
         templateProps.requestMessage = borrowRequest.requestMessage;
       }
 
-      const emailTemplate = EmailTemplates.borrowRequestReceived(templateProps);
-
-      emailPromise = createNotification({
-        userId: borrowRequest.lenderId,
-        type: 'BORROW_REQUEST_RECEIVED' as NotificationType,
-        title: 'New Borrow Request',
-        message: `${borrowRequest.borrower.name} wants to borrow your "${borrowRequest.item.name}"`,
-        sendEmail: true,
-        emailTemplate: {
-          subject: emailTemplate.subject,
-          html: emailTemplate.html,
-          to: borrowRequest.lender.email,
-        },
-      });
+      const template = EmailTemplates.borrowRequestReceived(templateProps);
+      emailTemplate = {
+        subject: template.subject,
+        html: template.html,
+        to: borrowRequest.lender.email,
+      };
     }
+
+    // Create single notification that handles both in-app and email
+    const notificationPromise = createNotification({
+      userId: borrowRequest.lenderId,
+      type: 'BORROW_REQUEST_RECEIVED' as NotificationType,
+      title: 'New Borrow Request',
+      message: `${borrowRequest.borrower.name} wants to borrow your "${borrowRequest.item.name}"`,
+      actionUrl: `/borrow-approval/${borrowRequest.id}`,
+      relatedItemId: borrowRequest.itemId,
+      relatedRequestId: borrowRequest.id,
+      sendEmail: !!emailTemplate,
+      emailTemplate,
+      metadata: {
+        borrowerName: borrowRequest.borrower.name,
+        itemName: borrowRequest.item.name,
+        requestMessage: borrowRequest.requestMessage,
+        videoUrl: borrowRequest.videoUrl,
+      },
+    });
 
     // Legacy SMS notification for backward compatibility
     const legacyNotificationData: Parameters<
@@ -134,12 +130,12 @@ export async function sendBorrowRequestReceivedNotification(
 
     // Wait for all notifications to complete
     const results = await Promise.allSettled(
-      [notificationPromise, emailPromise, legacySmsPromise].filter(Boolean)
+      [notificationPromise, legacySmsPromise].filter(Boolean)
     );
 
     // Log results for debugging
     results.forEach((result, index) => {
-      const types = ['in-app', 'email', 'SMS'];
+      const types = ['in-app+email', 'SMS'];
       if (result.status === 'rejected') {
         console.error(
           `Failed to send ${types[index]} notification:`,
@@ -151,8 +147,8 @@ export async function sendBorrowRequestReceivedNotification(
     return {
       success: true,
       inApp: results[0]?.status === 'fulfilled',
-      email: emailPromise ? results[1]?.status === 'fulfilled' : null,
-      sms: results[results.length - 1]?.status === 'fulfilled',
+      email: emailTemplate ? results[0]?.status === 'fulfilled' : null,
+      sms: results[1]?.status === 'fulfilled',
     };
   } catch (error) {
     console.error('Error sending borrow request received notification:', error);


### PR DESCRIPTION
## 🐛 Bug Fix: Eliminate Duplicate Notifications + Standardize Links

Fixes the duplicate borrow request notifications appearing in the message center and makes notification links consistent across channels.

## 📋 Issues Fixed

### 1. **Duplicate Notifications** ❌➡️✅
**Before**: Users saw 2-3 identical "New Borrow Request" notifications  
**After**: Users see 1 notification per borrow request

### 2. **Inconsistent Link Formats** ❌➡️✅
**Before**: 
- In-app notifications: `https://www.stufflibrary.org/lender/requests/{id}`
- Email notifications: `https://www.stufflibrary.org/borrow-approval/{id}`

**After**: 
- Both channels: `https://www.stufflibrary.org/borrow-approval/{id}`

## 🔍 Root Cause Analysis

The `sendBorrowRequestReceivedNotification()` function was creating **duplicate database entries** by calling `createNotification()` twice:

1. **First call**: In-app notification with `/lender/requests/{id}` link
2. **Second call**: Email notification with `sendEmail: true` and `/borrow-approval/{id}` link

Both calls created separate entries in the notification center, causing duplicates.

## 🛠️ Solution

### **Single Notification Approach**
- Combined in-app and email handling into **one** `createNotification()` call
- Uses `sendEmail: !!emailTemplate` parameter to conditionally send email
- Eliminates duplicate database entries

### **Standardized Link Format**  
- Changed `actionUrl` from `/lender/requests/{id}` to `/borrow-approval/{id}`
- Now consistent with email approval links
- Better user experience with unified approval interface

## 📝 Changes Made

### `src/lib/enhanced-notification-service.ts`
- **Removed**: Duplicate `createNotification()` calls
- **Added**: Single notification call with conditional email
- **Changed**: `actionUrl: \`/borrow-approval/${borrowRequest.id}\``
- **Fixed**: Promise handling and return status logic
- **Updated**: Logging to show "in-app+email" for combined notifications

## ✅ Testing Verification

- [x] **No Duplicates**: Single notification appears in message center
- [x] **Link Consistency**: In-app and email links both use `/borrow-approval/{id}`
- [x] **Email Delivery**: Email notifications still sent when lender has email
- [x] **Legacy SMS**: Backward-compatible SMS notifications still work
- [x] **Error Handling**: Proper error handling if email fails

## 🎯 Impact

- **Better UX**: No more confusing duplicate notifications
- **Consistency**: Unified approval link behavior across channels
- **Cleaner Code**: Reduced complexity in notification service
- **Performance**: Fewer database operations per borrow request

The notification center will now show clean, single notifications that link directly to the approval interface, matching the email experience.

🤖 Generated with [Claude Code](https://claude.ai/code)