### PR TITLE
Fix: Mux webhook signature verification failing due to import issue

### DIFF
--- a/src/app/api/webhooks/mux/route.ts
+++ b/src/app/api/webhooks/mux/route.ts
@@ -51,12 +51,8 @@ export async function POST(request: NextRequest) {
     });
 
     try {
-      const muxNode: any = await import('@mux/mux-node');
-      muxNode.Webhooks.verifyHeader(
-        rawBody,
-        signature,
-        process.env.MUX_WEBHOOK_SECRET
-      );
+      const { Webhooks } = await import('@mux/mux-node');
+      Webhooks.verifyHeader(rawBody, signature, process.env.MUX_WEBHOOK_SECRET);
       console.log('✅ Webhook signature verified successfully');
     } catch (signatureError) {
       console.log('❌ Signature verification failed:', {


### PR DESCRIPTION
## 🔧 Bug Fix: Mux Webhook Signature Verification

Fixes the root cause of Mux webhook 400 errors preventing video processing.

## 🐛 Issue Identified

Thanks to the enhanced logging from PR #190, we identified the exact error:

```
❌ Signature verification failed: {
  error: "Cannot read properties of undefined (reading 'verifyHeader')",
  signaturePreview: 't=1756515709,v1=781d...',
  bodyHash: 674
}
```

**Root Cause**: Dynamic import of `@mux/mux-node` was incorrect
- We were importing the entire module: `const muxNode = await import('@mux/mux-node')`
- Then trying to access: `muxNode.Webhooks.verifyHeader()`
- But `muxNode.Webhooks` was `undefined`

## ✅ Solution

**Fixed the import to use destructured import:**

```diff
- const muxNode: any = await import('@mux/mux-node');
- muxNode.Webhooks.verifyHeader(rawBody, signature, process.env.MUX_WEBHOOK_SECRET);

+ const { Webhooks } = await import('@mux/mux-node');
+ Webhooks.verifyHeader(rawBody, signature, process.env.MUX_WEBHOOK_SECRET);
```

## 🎯 Expected Impact

- ✅ **Webhook signature verification will work** 
- ✅ **Video processing will complete** (videoUrl will be updated in database)
- ✅ **Users will see videos** instead of "Processing video..." indefinitely
- ✅ **No more 400 webhook errors** in production logs

## 🧪 Evidence from Logs

The webhook logging shows everything else is working correctly:
- ✅ Webhook received and parsed
- ✅ Signature format is correct (`t=1756515709,v1=781d...`)
- ✅ Environment variables configured
- ❌ Only the import/verification step was failing

## 📝 Files Changed

- `src/app/api/webhooks/mux/route.ts`: Fixed dynamic import syntax

This should resolve the video processing issue that's been causing the infinite refresh problem and poor user experience.