### PR TITLE
Add active field migration for items table

### DIFF
--- a/prisma/migrations/20250901005504_add_active_field_to_items/migration.sql
+++ b/prisma/migrations/20250901005504_add_active_field_to_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."items" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,6 +198,7 @@ model Item {
   aiModel                String?         // e.g., "gemini-2.5-flash-image"
   synthIdWatermark       Boolean         @default(false)
   flags                  Json?           // e.g., ["person_detected"]
+  active                 Boolean         @default(true) // false for draft items during creation
   currentBorrowRequestId String?
   createdAt              DateTime        @default(now())
   updatedAt              DateTime        @updatedAt


### PR DESCRIPTION
## Summary

This PR adds a critical database migration for the `active` field in the items table, which is required for the watercolor item creation flow.

### Migration Details

- **Migration**: `20250901005504_add_active_field_to_items`
- **Change**: Adds `active BOOLEAN NOT NULL DEFAULT true` to the items table
- **Impact**: All existing items will have `active = true` by default

### Why This Migration Is Needed

The watercolor item creation flow requires items to exist in the database as drafts (with `active = false`) while AI processing occurs in the background. Once processing is complete, items are activated (set to `active = true`).

Without this field, production deployments will fail when trying to create draft items.

### Production Impact

- ✅ **Safe Migration**: Default value ensures existing items remain functional
- ✅ **Non-breaking**: All existing queries will continue to work
- ✅ **Fast Execution**: Simple column addition with default value
- ✅ **Backward Compatible**: No existing functionality depends on this field yet

### Testing

- ✅ Migration tested locally with `prisma migrate dev`
- ✅ Schema synchronization verified with `prisma db push`
- ✅ TypeScript compilation successful
- ✅ All existing functionality preserved

### Deployment Notes

This migration should be deployed **before** the watercolor feature branches to ensure the database schema is ready.

```sql
-- AlterTable
ALTER TABLE "public"."items" ADD COLUMN "active" BOOLEAN NOT NULL DEFAULT true;
```

🤖 Generated with [Claude Code](https://claude.ai/code)