### PR TITLE
Fix watercolor image display in borrow request page

### DIFF
--- a/src/app/borrow-request/page.tsx
+++ b/src/app/borrow-request/page.tsx
@@ -28,7 +28,14 @@ export default async function BorrowRequestPage({
   // Get the item details
   const item = await db.item.findUnique({
     where: { id: itemId },
-    include: {
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      imageUrl: true,
+      watercolorUrl: true,
+      watercolorThumbUrl: true,
+      ownerId: true,
       owner: {
         select: {
           id: true,

--- a/src/components/BorrowRequestClient.tsx
+++ b/src/components/BorrowRequestClient.tsx
@@ -32,6 +32,8 @@ interface Item {
   name: string;
   description: string | null;
   imageUrl: string | null;
+  watercolorUrl?: string | null;
+  watercolorThumbUrl?: string | null;
   owner: {
     id: string;
     name: string | null;
@@ -61,6 +63,11 @@ type RequestState =
 
 export function BorrowRequestClient({ item }: BorrowRequestClientProps) {
   const router = useRouter();
+
+  // Helper function to get the best available image URL (prioritize watercolor)
+  const getDisplayImageUrl = () => {
+    return item.watercolorUrl || item.watercolorThumbUrl || item.imageUrl;
+  };
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -546,11 +553,11 @@ export function BorrowRequestClient({ item }: BorrowRequestClientProps) {
                 >
                   owned by {item.owner.name}
                 </Typography>
-                {item.imageUrl && (
+                {getDisplayImageUrl() && (
                   <Box
                     sx={{
                       aspectRatio: '1',
-                      backgroundImage: `url(${item.imageUrl})`,
+                      backgroundImage: `url(${getDisplayImageUrl()})`,
                       backgroundSize: 'cover',
                       backgroundPosition: 'center',
                       borderRadius: 1,
@@ -700,11 +707,11 @@ export function BorrowRequestClient({ item }: BorrowRequestClientProps) {
                 >
                   owned by {item.owner.name}
                 </Typography>
-                {item.imageUrl && (
+                {getDisplayImageUrl() && (
                   <Box
                     sx={{
                       aspectRatio: '1',
-                      backgroundImage: `url(${item.imageUrl})`,
+                      backgroundImage: `url(${getDisplayImageUrl()})`,
                       backgroundSize: 'cover',
                       backgroundPosition: 'center',
                       borderRadius: 1,
@@ -1021,11 +1028,11 @@ export function BorrowRequestClient({ item }: BorrowRequestClientProps) {
                 >
                   owned by {item.owner.name}
                 </Typography>
-                {item.imageUrl && (
+                {getDisplayImageUrl() && (
                   <Box
                     sx={{
                       aspectRatio: '1',
-                      backgroundImage: `url(${item.imageUrl})`,
+                      backgroundImage: `url(${getDisplayImageUrl()})`,
                       backgroundSize: 'cover',
                       backgroundPosition: 'center',
                       borderRadius: 1,


### PR DESCRIPTION
## Summary

This PR fixes a watercolor consistency issue where the borrow request page was displaying original photos instead of watercolor illustrations, breaking the visual consistency of the application.

## Problem

Users reported that when viewing borrow request pages, they were seeing original item photos instead of the watercolor illustrations that are shown throughout the rest of the application. This created an inconsistent user experience.

## Root Cause

1. **Missing Interface Fields**: The `BorrowRequestClient` component's `Item` interface only included `imageUrl` but not `watercolorUrl` or `watercolorThumbUrl` fields
2. **Incomplete Database Query**: The database query in `/app/borrow-request/page.tsx` was not fetching watercolor fields from the database
3. **No Image Prioritization**: The component was directly using `item.imageUrl` without checking for available watercolor alternatives

## Solution

### 🎨 **Updated Component Interface**
```typescript
interface Item {
  id: string;
  name: string;
  description: string | null;
  imageUrl: string | null;
  watercolorUrl?: string | null;        // ✅ Added
  watercolorThumbUrl?: string | null;   // ✅ Added
  // ... other fields
}
```

### 🔧 **Added Image Prioritization Logic**
```typescript
const getDisplayImageUrl = () => {
  return item.watercolorUrl || item.watercolorThumbUrl || item.imageUrl;
};
```

### 🗄️ **Fixed Database Query**
Updated the Prisma query to include watercolor fields:
```typescript
select: {
  id: true,
  name: true,
  description: true,
  imageUrl: true,
  watercolorUrl: true,        // ✅ Added
  watercolorThumbUrl: true,   // ✅ Added
  // ... other fields
}
```

### 🖼️ **Updated All Image References**
Replaced direct `item.imageUrl` usage with `getDisplayImageUrl()` throughout the component.

## Testing

- ✅ All tests pass (193 passed, 2 skipped)
- ✅ TypeScript compilation successful
- ✅ ESLint validation passed
- ✅ Follows the same image prioritization pattern used throughout the app

## User Experience Impact

- **Before**: Borrow request pages showed original photos, creating visual inconsistency
- **After**: Borrow request pages show watercolor illustrations, maintaining consistent visual experience
- **Fallback**: Gracefully falls back to original photos if watercolor isn't available

## Technical Notes

- Maintains backward compatibility with items that don't have watercolor illustrations
- Uses the same image prioritization logic as other components in the app
- No breaking changes to existing functionality

This ensures the borrow request flow maintains the same beautiful, consistent watercolor aesthetic that users see throughout the rest of StuffLibrary! 🎨

🤖 Generated with [Claude Code](https://claude.ai/code)