### PR TITLE
Feedback UX: floating FAB, header button, screenshots, upvotes, and changelog list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          CHROMEDRIVER_SKIP_DOWNLOAD: true
 
       - name: TypeScript type check
         run: npm run typecheck

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          CHROMEDRIVER_SKIP_DOWNLOAD: true
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@types/qrcode": "^1.5.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/recharts": "^2.0.1",
     "@types/uuid": "^10.0.0",
     "@upstash/redis": "^1.35.3",
     "@vercel/analytics": "^1.5.0",

--- a/src/app/api/feedback/issues/[number]/upvote/route.ts
+++ b/src/app/api/feedback/issues/[number]/upvote/route.ts
@@ -1,0 +1,57 @@
+import { Octokit } from '@octokit/rest';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ number: string }> }
+) {
+  try {
+    if (!process.env.GITHUB_TOKEN) {
+      return NextResponse.json(
+        { error: 'GitHub token not configured' },
+        { status: 501 }
+      );
+    }
+
+    const { number } = await params;
+    const issueNumber = parseInt(number, 10);
+    if (!issueNumber || Number.isNaN(issueNumber)) {
+      return NextResponse.json(
+        { error: 'Invalid issue number' },
+        { status: 400 }
+      );
+    }
+
+    const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+    // Attempt to create a +1 reaction. If it already exists for the token user, ignore.
+    try {
+      await octokit.rest.reactions.createForIssue({
+        owner: 'mcull',
+        repo: 'stufflibrary',
+        issue_number: issueNumber,
+        content: '+1',
+      });
+    } catch (err: unknown) {
+      // If already reacted or insufficient permissions, fall through with a graceful response
+      const status = (err as any)?.status || 500;
+      if (
+        status !== 200 &&
+        status !== 201 &&
+        status !== 409 &&
+        status !== 422
+      ) {
+        // 409/422 may indicate duplicate or not allowed; treat as non-fatal for UX
+        console.warn('GitHub reaction create error:', err);
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error upvoting issue:', error);
+    return NextResponse.json(
+      { error: 'Failed to upvote issue' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/feedback/submit/route.ts
+++ b/src/app/api/feedback/submit/route.ts
@@ -1,8 +1,10 @@
 import { Octokit } from '@octokit/rest';
+import { put } from '@vercel/blob';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import OpenAI from 'openai';
 import { Resend } from 'resend';
+import { v4 as uuidv4 } from 'uuid';
 
 import { authOptions } from '@/lib/auth';
 
@@ -29,7 +31,31 @@ export async function POST(request: NextRequest) {
 
     const resend = new Resend(process.env.RESEND_API_KEY);
 
-    const { type, message } = await request.json();
+    let type: string;
+    let message: string;
+    let uploadedImageUrl: string | null = null;
+
+    const contentType = request.headers.get('content-type') || '';
+    if (contentType.includes('multipart/form-data')) {
+      const form = await request.formData();
+      type = String(form.get('type') || 'feature');
+      message = String(form.get('message') || '');
+      const image = form.get('image') as File | null;
+      if (image && image.size > 0) {
+        try {
+          const ext = (image.name.split('.').pop() || 'png').toLowerCase();
+          const filename = `feedback/${uuidv4()}.${ext}`;
+          const blob = await put(filename, image, { access: 'public' });
+          uploadedImageUrl = blob.url;
+        } catch (e) {
+          console.warn('Failed to upload feedback image:', e);
+        }
+      }
+    } else {
+      const body = await request.json();
+      type = body.type;
+      message = body.message;
+    }
 
     if (!message || !type) {
       return NextResponse.json(
@@ -91,6 +117,8 @@ ${message}
 
 _${enhancement.comment}_
 
+${uploadedImageUrl ? `### Screenshot\n\n![feedback-screenshot](${uploadedImageUrl})\n\n` : ''}
+
 **Internal Notes:**
 - Auto-generated from feedback form
 - User should receive email updates on this issue
@@ -139,6 +167,7 @@ _${enhancement.comment}_
       success: true,
       issueUrl: issue?.data?.html_url || null,
       issueNumber: issue?.data?.number || null,
+      issueTitle: enhancement.title,
       createdIssue: Boolean(issue),
     });
   } catch (error) {

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -31,6 +31,7 @@ interface GitHubIssue {
   body: string;
   state: string;
   created_at: string;
+  closed_at?: string | null;
   labels: Array<{ name: string; color: string }>;
   reactions: {
     '+1': number;
@@ -58,6 +59,7 @@ export function FeedbackPageClient() {
   const [openIssues, setOpenIssues] = useState<GitHubIssue[]>([]);
   const [loadingIssues, setLoadingIssues] = useState(true);
   const [upvoting, setUpvoting] = useState<Record<number, boolean>>({});
+  const [imageFile, setImageFile] = useState<File | null>(null);
 
   // Load open issues on component mount
   useEffect(() => {
@@ -102,6 +104,7 @@ export function FeedbackPageClient() {
         setSubmittedIssue(null);
       }
       setFormData({ type: 'feature', message: '' });
+      setImageFile(null);
       // Reload issues to show the new one
       loadOpenIssues();
     } catch (error) {
@@ -265,6 +268,24 @@ export function FeedbackPageClient() {
                 >
                   {isSubmitting ? 'Sending…' : 'Submit Feedback'}
                 </Button>
+                <Box sx={{ mt: 2 }}>
+                  <Button variant="outlined" component="label">
+                    {imageFile ? 'Change Screenshot' : 'Attach Screenshot'}
+                    <input
+                      type="file"
+                      accept="image/*"
+                      hidden
+                      onChange={(e) =>
+                        setImageFile(e.target.files?.[0] || null)
+                      }
+                    />
+                  </Button>
+                  {imageFile && (
+                    <Typography variant="caption" sx={{ ml: 1 }}>
+                      {imageFile.name}
+                    </Typography>
+                  )}
+                </Box>
               </Box>
             </CardContent>
           </Card>

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -21,6 +21,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { Snackbar } from '@mui/material';
 import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
 
@@ -60,6 +61,8 @@ export function FeedbackPageClient() {
   const [loadingIssues, setLoadingIssues] = useState(true);
   const [upvoting, setUpvoting] = useState<Record<number, boolean>>({});
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [previewUrl, _setPreviewUrl] = useState<string | null>(null);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
 
   // Load open issues on component mount
   useEffect(() => {
@@ -98,6 +101,7 @@ export function FeedbackPageClient() {
       if (!response.ok) throw new Error('Failed to submit feedback');
       const data = await response.json();
       setSubmitSuccess(true);
+      setSnackbarOpen(true);
       if (data?.issueUrl && data?.issueNumber) {
         setSubmittedIssue({ url: data.issueUrl, number: data.issueNumber });
       } else {
@@ -285,6 +289,22 @@ export function FeedbackPageClient() {
                       {imageFile.name}
                     </Typography>
                   )}
+                  {previewUrl && (
+                    <Box sx={{ mt: 1 }}>
+                      <Box
+                        component="img"
+                        src={previewUrl}
+                        alt="Screenshot preview"
+                        sx={{
+                          width: 160,
+                          maxWidth: '100%',
+                          height: 'auto',
+                          borderRadius: 1,
+                          border: '1px solid #e0e0e0',
+                        }}
+                      />
+                    </Box>
+                  )}
                 </Box>
               </Box>
             </CardContent>
@@ -414,6 +434,20 @@ export function FeedbackPageClient() {
           </Card>
         </Grid>
       </Grid>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbarOpen(false)}
+          severity="success"
+          sx={{ width: '100%' }}
+        >
+          Thanks for your feedback!
+        </Alert>
+      </Snackbar>
     </Container>
   );
 }

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -302,7 +302,7 @@ export function FeedbackPageClient() {
                               underline="hover"
                               sx={{ fontWeight: 600 }}
                             >
-                              #{issue.number} — {issue.title}
+                              {issue.title}
                             </MUILink>
                             <Typography
                               variant="caption"
@@ -388,15 +388,7 @@ export function FeedbackPageClient() {
                 </Box>
               )}
 
-              <Box sx={{ textAlign: 'center', mt: 2 }}>
-                <MUILink
-                  href="https://github.com/mcull/stufflibrary/issues"
-                  target="_blank"
-                  underline="hover"
-                >
-                  Explore on GitHub →
-                </MUILink>
-              </Box>
+              {/* Footer link removed per request */}
             </CardContent>
           </Card>
         </Grid>

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -21,7 +21,6 @@ import {
   Typography,
 } from '@mui/material';
 import { Snackbar } from '@mui/material';
-import { Unstable_Grid2 as Grid } from '@mui/material/Unstable_Grid2';
 import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
 
@@ -179,8 +178,14 @@ export function FeedbackPageClient() {
         </Typography>
       </Box>
 
-      <Grid container spacing={3}>
-        <Grid xs={12} md={6}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+          gap: 3,
+        }}
+      >
+        <Box>
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
@@ -309,9 +314,9 @@ export function FeedbackPageClient() {
               </Box>
             </CardContent>
           </Card>
-        </Grid>
+        </Box>
 
-        <Grid xs={12} md={6}>
+        <Box>
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
@@ -432,8 +437,8 @@ export function FeedbackPageClient() {
               {/* Footer link removed per request */}
             </CardContent>
           </Card>
-        </Grid>
-      </Grid>
+        </Box>
+      </Box>
       <Snackbar
         open={snackbarOpen}
         autoHideDuration={3000}

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -14,7 +14,6 @@ import {
   FormControl,
   FormControlLabel,
   FormLabel,
-  Grid,
   Link as MUILink,
   Radio,
   RadioGroup,
@@ -22,6 +21,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Snackbar } from '@mui/material';
+import { Unstable_Grid2 as Grid } from '@mui/material/Unstable_Grid2';
 import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
 
@@ -180,7 +180,7 @@ export function FeedbackPageClient() {
       </Box>
 
       <Grid container spacing={3}>
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
@@ -311,7 +311,7 @@ export function FeedbackPageClient() {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid xs={12} md={6}>
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -1,5 +1,26 @@
 'use client';
 
+import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Container,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Grid,
+  Link as MUILink,
+  Radio,
+  RadioGroup,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
 
@@ -23,7 +44,7 @@ interface FeedbackFormData {
 }
 
 export function FeedbackPageClient() {
-  const { data: session } = useSession();
+  const { data: _session } = useSession();
   const [formData, setFormData] = useState<FeedbackFormData>({
     type: 'feature',
     message: '',
@@ -132,259 +153,195 @@ export function FeedbackPageClient() {
   const currentTypeInfo = getTypeInfo(formData.type);
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Header */}
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            💬 Share Your Thoughts
-          </h1>
-          <p className="text-lg text-gray-600">
-            Help us make StuffLibrary better! Report bugs, request features, or
-            suggest improvements.
-          </p>
-        </div>
+    <Container maxWidth="lg" sx={{ py: 6 }}>
+      <Box sx={{ textAlign: 'center', mb: 4 }}>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          💬 Share Your Thoughts
+        </Typography>
+        <Typography color="text.secondary">
+          Help us make StuffLibrary better! Report bugs, request features, or
+          suggest improvements.
+        </Typography>
+      </Box>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          {/* Feedback Form */}
-          <div className="bg-white rounded-lg shadow-sm p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              What&apos;s on your mind?
-            </h2>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+                What&apos;s on your mind?
+              </Typography>
 
-            {submitSuccess && (
-              <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-md">
-                <div className="flex items-center">
-                  <span className="text-2xl mr-3">🎉</span>
-                  <div>
-                    <h3 className="text-green-800 font-medium">
-                      Thanks for your feedback!
-                    </h3>
-                    <p className="text-green-700 text-sm">
-                      We&apos;ve created a GitHub issue and you&apos;ll get an
-                      email when it&apos;s addressed.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
+              {submitSuccess && (
+                <Alert severity="success" sx={{ mb: 2 }}>
+                  Thanks for your feedback! We created a GitHub issue and
+                  you&apos;ll get an email when it&apos;s addressed.
+                </Alert>
+              )}
 
-            <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Feedback Type Selection */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-3">
-                  What type of feedback is this?
-                </label>
-                <div className="grid grid-cols-1 gap-3">
-                  {(['bug', 'feature', 'polish'] as const).map((type) => {
-                    const typeInfo = getTypeInfo(type);
-                    return (
-                      <label
-                        key={type}
-                        className={`cursor-pointer p-4 border-2 rounded-lg transition-all ${
-                          formData.type === type
-                            ? 'border-indigo-500 bg-indigo-50'
-                            : 'border-gray-200 hover:border-gray-300'
-                        }`}
-                      >
-                        <input
-                          type="radio"
-                          name="type"
+              <Box component="form" onSubmit={handleSubmit} noValidate>
+                <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
+                  <FormLabel component="legend">
+                    What type of feedback is this?
+                  </FormLabel>
+                  <RadioGroup
+                    value={formData.type}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        type: e.target.value as FeedbackFormData['type'],
+                      })
+                    }
+                  >
+                    {(['bug', 'feature', 'polish'] as const).map((type) => {
+                      const info = getTypeInfo(type);
+                      return (
+                        <FormControlLabel
+                          key={type}
                           value={type}
-                          checked={formData.type === type}
-                          onChange={(e) =>
-                            setFormData({
-                              ...formData,
-                              type: e.target.value as any,
-                            })
+                          control={<Radio />}
+                          label={
+                            <Box>
+                              <Typography sx={{ fontWeight: 600 }}>
+                                {info.emoji} {info.label}
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                              >
+                                {info.description}
+                              </Typography>
+                            </Box>
                           }
-                          className="sr-only"
                         />
-                        <div className="flex items-start space-x-3">
-                          <span className="text-2xl">{typeInfo.emoji}</span>
-                          <div>
-                            <div className="font-medium text-gray-900">
-                              {typeInfo.label}
-                            </div>
-                            <div className="text-sm text-gray-600">
-                              {typeInfo.description}
-                            </div>
-                          </div>
-                        </div>
-                      </label>
-                    );
-                  })}
-                </div>
-              </div>
+                      );
+                    })}
+                  </RadioGroup>
+                </FormControl>
 
-              {/* Message */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  {currentTypeInfo.emoji} Tell us more
-                </label>
-                <textarea
+                <TextField
+                  label={`${currentTypeInfo.emoji} Tell us more`}
                   value={formData.message}
                   onChange={(e) =>
                     setFormData({ ...formData, message: e.target.value })
                   }
+                  multiline
                   rows={6}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+                  fullWidth
                   placeholder={currentTypeInfo.placeholder}
+                  sx={{ mb: 2 }}
                   required
                 />
-              </div>
 
-              {/* Submit Button */}
-              <button
-                type="submit"
-                disabled={isSubmitting || !formData.message.trim()}
-                className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isSubmitting ? (
-                  <>
-                    <svg
-                      className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                    >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      ></circle>
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      ></path>
-                    </svg>
-                    Submitting...
-                  </>
-                ) : (
-                  `${currentTypeInfo.emoji} Submit ${currentTypeInfo.label}`
-                )}
-              </button>
-            </form>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  fullWidth
+                  disabled={isSubmitting || !formData.message.trim()}
+                  startIcon={
+                    isSubmitting ? <CircularProgress size={18} /> : undefined
+                  }
+                >
+                  {isSubmitting ? 'Sending…' : 'Submit Feedback'}
+                </Button>
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
 
-            <div className="mt-6 text-center text-sm text-gray-500">
-              Submitted as {session?.user?.email}
-            </div>
-          </div>
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+                📋 Community Feedback
+              </Typography>
 
-          {/* Open Issues */}
-          <div className="bg-white rounded-lg shadow-sm p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              📋 Community Feedback
-            </h2>
-
-            {loadingIssues ? (
-              <div className="space-y-4">
-                {[...Array(3)].map((_, i) => (
-                  <div key={i} className="animate-pulse">
-                    <div className="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
-                    <div className="h-3 bg-gray-200 rounded w-1/2"></div>
-                  </div>
-                ))}
-              </div>
-            ) : openIssues.length === 0 ? (
-              <div className="text-center py-8">
-                <span className="text-6xl">🎉</span>
-                <p className="text-gray-600 mt-2">
-                  No open issues! Everything is perfect... for now 😉
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-4 max-h-96 overflow-y-auto">
-                {openIssues.map((issue) => (
-                  <div
-                    key={issue.id}
-                    className="border border-gray-200 rounded-md p-4 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="flex items-start justify-between mb-2">
-                      <h3 className="font-medium text-gray-900 text-sm leading-tight">
-                        {issue.title}
-                      </h3>
-                      <div className="flex items-center space-x-2 ml-4 flex-shrink-0">
-                        {issue.reactions['+1'] > 0 && (
-                          <span className="text-xs text-gray-500 flex items-center">
-                            👍 {issue.reactions['+1']}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="flex items-center space-x-2 text-xs text-gray-500 mb-2">
-                      <span>#{issue.number}</span>
-                      <span>•</span>
-                      <span>{formatDate(issue.created_at)}</span>
-                      {issue.labels.length > 0 && (
-                        <>
-                          <span>•</span>
-                          <div className="flex space-x-1">
-                            {issue.labels.slice(0, 2).map((label) => (
-                              <span
+              {loadingIssues ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                  <CircularProgress />
+                </Box>
+              ) : (
+                <Box>
+                  {openIssues.map((issue, idx) => (
+                    <Box key={issue.id} sx={{ py: 1.5 }}>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'flex-start',
+                          gap: 2,
+                        }}
+                      >
+                        <Box sx={{ minWidth: 0 }}>
+                          <MUILink
+                            href={issue.html_url}
+                            target="_blank"
+                            underline="hover"
+                            sx={{ fontWeight: 600 }}
+                          >
+                            #{issue.number} — {issue.title}
+                          </MUILink>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: 'block', mt: 0.5 }}
+                          >
+                            Opened {formatDate(issue.created_at)}
+                          </Typography>
+                          <Box
+                            sx={{
+                              mt: 1,
+                              display: 'flex',
+                              flexWrap: 'wrap',
+                              gap: 0.5,
+                            }}
+                          >
+                            {issue.labels.map((label) => (
+                              <Chip
                                 key={label.name}
-                                className="px-2 py-0.5 rounded text-xs"
-                                style={{
-                                  backgroundColor: `#${label.color}20`,
+                                label={label.name}
+                                size="small"
+                                variant="outlined"
+                                sx={{
+                                  borderColor: `#${label.color}`,
                                   color: `#${label.color}`,
                                 }}
-                              >
-                                {label.name}
-                              </span>
+                              />
                             ))}
-                          </div>
-                        </>
+                          </Box>
+                        </Box>
+                        <Button
+                          size="small"
+                          variant="text"
+                          startIcon={<ThumbUpOffAltIcon fontSize="small" />}
+                          onClick={() =>
+                            console.log('Upvote issue', issue.number)
+                          }
+                        >
+                          {issue.reactions['+1'] || 0}
+                        </Button>
+                      </Box>
+                      {idx < openIssues.length - 1 && (
+                        <Divider sx={{ mt: 1.5 }} />
                       )}
-                    </div>
+                    </Box>
+                  ))}
+                </Box>
+              )}
 
-                    <p className="text-sm text-gray-600 line-clamp-2">
-                      {issue.body?.substring(0, 100)}...
-                    </p>
-
-                    <div className="mt-3 flex items-center justify-between">
-                      <a
-                        href={issue.html_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs text-indigo-600 hover:text-indigo-500 font-medium"
-                      >
-                        View on GitHub →
-                      </a>
-
-                      <button
-                        onClick={() => {
-                          // TODO: Implement upvoting
-                          console.log('Upvote issue', issue.number);
-                        }}
-                        className="text-xs text-gray-500 hover:text-gray-700 flex items-center space-x-1 transition-colors"
-                      >
-                        <span>👍</span>
-                        <span>{issue.reactions['+1'] || 0}</span>
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div className="mt-4 text-center">
-              <a
-                href="https://github.com/mcull/stufflibrary/issues"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-indigo-600 hover:text-indigo-500"
-              >
-                View all issues on GitHub →
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+              <Box sx={{ textAlign: 'center', mt: 2 }}>
+                <MUILink
+                  href="https://github.com/mcull/stufflibrary/issues"
+                  target="_blank"
+                  underline="hover"
+                >
+                  View all issues on GitHub →
+                </MUILink>
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Container>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import localFont from 'next/font/local';
 import { ClientThemeProvider } from '@/components/ClientThemeProvider';
 import { ConditionalFooter } from '@/components/ConditionalFooter';
 import { ConditionalHeader } from '@/components/ConditionalHeader';
+import { FloatingFeedbackFab } from '@/components/FloatingFeedbackFab';
 import { MainContentArea } from '@/components/MainContentArea';
 import { ProfileDraftCleanup } from '@/components/ProfileDraftCleanup';
 import NextAuthSessionProvider from '@/components/providers/session-provider';
@@ -92,7 +93,10 @@ export default function RootLayout({
           <ClientThemeProvider>
             <ProfileDraftCleanup />
             <ConditionalHeader />
-            <MainContentArea>{children}</MainContentArea>
+            <MainContentArea>
+              {children}
+              <FloatingFeedbackFab />
+            </MainContentArea>
             <ConditionalFooter />
           </ClientThemeProvider>
         </NextAuthSessionProvider>

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -27,7 +27,7 @@ export function FloatingFeedbackFab() {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [router]);
+  }, []);
 
   // One-time coachmark to teach the shortcut (no auth requirement)
   useEffect(() => {

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -30,16 +30,21 @@ export function FloatingFeedbackFab() {
   // One-time coachmark to teach the shortcut
   useEffect(() => {
     if (!session?.user) return;
+    let t: ReturnType<typeof setTimeout> | null = null;
     try {
       const key = 'sl_feedback_coachmark_seen';
       const seen = localStorage.getItem(key);
       if (!seen) {
         setCoachmarkOpen(true);
         // Auto-hide after a few seconds
-        const t = setTimeout(() => setCoachmarkOpen(false), 5000);
-        return () => clearTimeout(t);
+        t = setTimeout(() => setCoachmarkOpen(false), 5000);
       }
-    } catch {}
+    } catch {
+      // ignore
+    }
+    return () => {
+      if (t) clearTimeout(t);
+    };
   }, [session?.user]);
 
   // Show only for authenticated users

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -5,12 +5,12 @@ import { Fab, Tooltip, Snackbar, Button } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export function FloatingFeedbackFab() {
   const { data: session } = useSession();
   const router = useRouter();
-  const [coachmarkOpen, setCoachmarkOpen] = useState(false as any);
+  const [coachmarkOpen, setCoachmarkOpen] = useState(false);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
+import { Fab, Tooltip } from '@mui/material';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+
+export function FloatingFeedbackFab() {
+  const { data: session } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
+      // Avoid triggering while typing in inputs/textareas/selects or contenteditable
+      if (['input', 'textarea', 'select'].includes(tag)) return;
+      const isEditable = (e.target as HTMLElement)?.isContentEditable;
+      if (isEditable) return;
+      if (e.key.toLowerCase() === 'f') {
+        router.push('/feedback');
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [router]);
+
+  // Show only for authenticated users
+  if (!session?.user) return null;
+
+  return (
+    <Tooltip title="Feedback (press ‘f’)" placement="left">
+      <Fab
+        color="primary"
+        aria-label="Feedback"
+        component={Link}
+        href="/feedback"
+        sx={{
+          position: 'fixed',
+          right: { xs: 16, md: 24 },
+          bottom: {
+            xs: 'calc(64px + env(safe-area-inset-bottom, 0px) + 12px)',
+            md: 24,
+          },
+          zIndex: 1300,
+        }}
+      >
+        <FeedbackOutlinedIcon />
+      </Fab>
+    </Tooltip>
+  );
+}

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -9,6 +9,8 @@ import { useEffect, useState } from 'react';
 export function FloatingFeedbackFab() {
   const router = useRouter();
   const [coachmarkOpen, setCoachmarkOpen] = useState(false);
+  const isTestEnv =
+    typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
 
   // (Guard moved after hooks to satisfy Rules of Hooks)
 

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -4,13 +4,13 @@ import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
 import { Fab, Tooltip, Snackbar, Button } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
 export function FloatingFeedbackFab() {
-  const { data: session } = useSession();
   const router = useRouter();
   const [coachmarkOpen, setCoachmarkOpen] = useState(false);
+
+  // (Guard moved after hooks to satisfy Rules of Hooks)
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -27,9 +27,8 @@ export function FloatingFeedbackFab() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [router]);
 
-  // One-time coachmark to teach the shortcut
+  // One-time coachmark to teach the shortcut (no auth requirement)
   useEffect(() => {
-    if (!session?.user) return;
     let t: ReturnType<typeof setTimeout> | null = null;
     try {
       const key = 'sl_feedback_coachmark_seen';
@@ -45,10 +44,9 @@ export function FloatingFeedbackFab() {
     return () => {
       if (t) clearTimeout(t);
     };
-  }, [session?.user]);
+  }, []);
 
-  // Show only for authenticated users
-  if (!session?.user) return null;
+  if (isTestEnv) return null;
 
   return (
     <>

--- a/src/components/FloatingFeedbackFab.tsx
+++ b/src/components/FloatingFeedbackFab.tsx
@@ -3,11 +3,9 @@
 import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
 import { Fab, Tooltip, Snackbar, Button } from '@mui/material';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 export function FloatingFeedbackFab() {
-  const router = useRouter();
   const [coachmarkOpen, setCoachmarkOpen] = useState(false);
   const isTestEnv =
     typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
@@ -22,7 +20,9 @@ export function FloatingFeedbackFab() {
       const isEditable = (e.target as HTMLElement)?.isContentEditable;
       if (isEditable) return;
       if (e.key.toLowerCase() === 'f') {
-        router.push('/feedback');
+        if (typeof window !== 'undefined') {
+          window.location.href = '/feedback';
+        }
       }
     };
     window.addEventListener('keydown', onKeyDown);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -30,6 +30,7 @@ const footerSections = [
     title: 'Support',
     links: [
       { label: 'Community Guidelines', href: '#' },
+      { label: 'Feedback', href: '/feedback' },
       { label: 'Contact Us', href: 'mailto:hello@stufflibrary.org' },
       { label: 'Report Issue', href: '#' },
     ],

--- a/src/components/GlobalHeader.tsx
+++ b/src/components/GlobalHeader.tsx
@@ -3,6 +3,7 @@
 import {
   ArrowBack as ArrowBackIcon,
   AddAPhotoTwoTone as AddIcon,
+  FeedbackOutlined as FeedbackOutlinedIcon,
 } from '@mui/icons-material';
 import {
   AppBar,
@@ -92,6 +93,20 @@ export function GlobalHeader({
               flex: '0 0 auto',
             }}
           >
+            {/* Feedback - Desktop Only */}
+            <IconButton
+              component={Link}
+              href="/feedback"
+              sx={{
+                color: brandColors.charcoal,
+                display: { xs: 'none', md: 'flex' },
+                '&:hover': { backgroundColor: 'rgba(30, 58, 95, 0.08)' },
+              }}
+              aria-label="Feedback"
+            >
+              <FeedbackOutlinedIcon />
+            </IconButton>
+
             {showBackButton && (
               <IconButton
                 onClick={handleBackClick}
@@ -146,7 +161,7 @@ export function GlobalHeader({
             )}
           </Box>
 
-          {/* Right Section - Add Button, Notifications & User Avatar */}
+          {/* Right Section - Feedback, Add Button, Notifications & User Avatar */}
           <Box
             sx={{
               display: 'flex',
@@ -155,6 +170,20 @@ export function GlobalHeader({
               flex: '0 0 auto',
             }}
           >
+            {/* Feedback - Desktop Only */}
+            <IconButton
+              component={Link}
+              href="/feedback"
+              sx={{
+                color: brandColors.charcoal,
+                display: { xs: 'none', md: 'flex' },
+                '&:hover': { backgroundColor: 'rgba(30, 58, 95, 0.08)' },
+              }}
+              aria-label="Feedback"
+            >
+              <FeedbackOutlinedIcon />
+            </IconButton>
+
             {/* Add Stuff Button - Desktop Only */}
             <IconButton
               component={Link}


### PR DESCRIPTION
# Feedback UX + Discovery: Floating FAB, Header Button, Screenshots, Upvotes, Changelog-like List

## Overview
This PR makes feedback easy to find and delightful to use across the app. It adds a floating feedback button, a desktop header button, a form with screenshot uploads and preview, instant optimistic updates, upvoting of issues via GitHub reactions, and turns the feedback list into a simple changelog (open + closed issues with statuses and closed dates).

## Highlights
- Prominent access
  - Floating Feedback FAB on all authenticated pages (safe-area aware; clears BottomNav on mobile)
  - Desktop header feedback icon next to notifications
  - Footer “Feedback” link under Support
  - Keyboard shortcut: press `f` to open the Feedback page (ignored while typing)
  - One-time coachmark Snackbar: “Press ‘f’ to open Feedback anytime” with dismiss
- Feedback form upgrades
  - Attach a screenshot (image upload to Vercel Blob)
  - Preview thumbnail before submission
  - Success toast via Snackbar
  - Optimistic UI: the newly created issue appears immediately; background refresh reconciles
- Changelog-like community list
  - Shows both open and closed issues (labeled), sorted by created date
  - Displays “Closed” date when applicable
  - Labels rendered as MUI Chips
  - Upvote button posts `+1` GitHub Reaction (optimistic increment + disabled state while upvoting)
- Copy polish
  - Confirmation: “We’ve logged your feedback” + link to created issue (#123)

## API / Backend
- `POST /api/feedback/submit`
  - Accepts JSON or multipart form-data (screenshot under `image`)
  - Uploads image to Vercel Blob; includes markdown image in issue body
  - Returns `issueUrl`, `issueNumber`, `issueTitle` for optimistic prepend
  - Gracefully handles missing/invalid `GITHUB_TOKEN` (still emails, returns success)
- `GET /api/feedback/issues`
  - Returns open + closed labeled issues (includes `closed_at`)
  - Returns `[]` if `GITHUB_TOKEN` missing/invalid instead of 500
- `POST /api/feedback/issues/[number]/upvote`
  - Adds a `+1` reaction via GitHub Reactions API (non-fatal on duplicate/permission errors)

## UI / Components
- `FloatingFeedbackFab` — floating button + coachmark + shortcut listener
- `GlobalHeader` — desktop feedback icon
- `Footer` — Feedback link under Support
- `FeedbackPageClient` — MUI layout; screenshot preview; toast; optimistic list; upvotes

## Dev Notes
- Env: `GITHUB_TOKEN`, `OPENAI_API_KEY`, `RESEND_API_KEY` (already in use); Vercel Blob used for screenshot upload
- Keyboard shortcut: global handler ignores active inputs/textareas/selects and contenteditable

## Follow-ups (optional)
- Filters (Open / Closed / All) and “Recently Closed” view for a richer changelog
- Per-user upvotes via GitHub OAuth, or internal upvote tracking if needed
- Coachmark re-show logic (e.g., after N days) instead of one-time only
