### PR TITLE
Feedback: indicate closed issues and disable voting on closed

### DIFF
--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -355,7 +355,10 @@ export function FeedbackPageClient() {
                   {openIssues.map((issue, idx) => {
                     const _isClosed = issue.state.toLowerCase() === 'closed';
                     return (
-                      <Box key={issue.id} sx={{ py: 1.5 }}>
+                      <Box
+                        key={issue.id}
+                        sx={{ py: 1.5, opacity: _isClosed ? 0.88 : 1 }}
+                      >
                         <Box
                           sx={{
                             display: 'flex',
@@ -392,6 +395,18 @@ export function FeedbackPageClient() {
                                 gap: 0.5,
                               }}
                             >
+                              {_isClosed && (
+                                <Chip
+                                  label="Closed"
+                                  size="small"
+                                  variant="outlined"
+                                  sx={{
+                                    backgroundColor: '#f3f4f6',
+                                    color: '#6b7280',
+                                    borderColor: '#e5e7eb',
+                                  }}
+                                />
+                              )}
                               {issue.labels.map((label) => (
                                 <Chip
                                   key={label.name}
@@ -410,8 +425,16 @@ export function FeedbackPageClient() {
                             size="small"
                             variant="text"
                             startIcon={<ThumbUpOffAltIcon fontSize="small" />}
-                            disabled={Boolean(upvoting[issue.number])}
+                            disabled={
+                              Boolean(upvoting[issue.number]) || _isClosed
+                            }
+                            title={
+                              _isClosed
+                                ? 'Voting disabled on closed issues'
+                                : undefined
+                            }
                             onClick={async () => {
+                              if (_isClosed) return;
                               try {
                                 setUpvoting((s) => ({
                                   ...s,


### PR DESCRIPTION
Changes\n- Adds a subtle  chip and reduced opacity for closed feedback issues so they’re visually distinct.\n- Disables the upvote button when an issue is closed while still displaying the existing vote count.\n- Keeps issue links and metadata intact (opened/closed dates, labels).\n\nWhy\n- Prevents new votes on closed items and clarifies status at a glance without removing historical context.\n\nQA\n- Closed issues: show  chip, slightly dimmed, vote button disabled with tooltip; count is still shown.\n- Open issues: appearance unchanged; voting still works and increments count optimistically.\n