### PR TITLE
Feedback: internal voting (per user) + UI integration

### DIFF
--- a/prisma/migrations/20250922173907_feedback_votes/migration.sql
+++ b/prisma/migrations/20250922173907_feedback_votes/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "public"."feedback_votes" (
+    "id" TEXT NOT NULL,
+    "issueNumber" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "feedback_votes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "feedback_votes_issueNumber_idx" ON "public"."feedback_votes"("issueNumber");
+
+-- CreateIndex
+CREATE INDEX "feedback_votes_userId_idx" ON "public"."feedback_votes"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "feedback_votes_issueNumber_userId_key" ON "public"."feedback_votes"("issueNumber", "userId");
+
+-- AddForeignKey
+ALTER TABLE "public"."feedback_votes" ADD CONSTRAINT "feedback_votes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,7 @@ model User {
   blockedIPs            BlockedIP[]
   auditLogs             AuditLog[]
   complianceReports     ComplianceReport[]
+  feedbackVotes         FeedbackVote[]
   complianceAdmin       ComplianceReport[] @relation("ComplianceAdmin")
 
   @@map("users")
@@ -577,6 +578,21 @@ model ComplianceReport {
   @@index([userId])
   @@index([generatedAt])
   @@map("compliance_reports")
+}
+
+// Tracks internal votes for GitHub feedback issues per StuffLibrary user
+model FeedbackVote {
+  id          String   @id @default(cuid())
+  issueNumber Int
+  userId      String
+  createdAt   DateTime @default(now())
+
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([issueNumber, userId])
+  @@index([issueNumber])
+  @@index([userId])
+  @@map("feedback_votes")
 }
 
 enum SecurityEventType {

--- a/src/app/api/feedback/issues/[number]/upvote/route.ts
+++ b/src/app/api/feedback/issues/[number]/upvote/route.ts
@@ -11,7 +11,8 @@ export async function POST(
 ) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    const userId = (session?.user as { id?: string })?.id;
+    if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
@@ -29,12 +30,12 @@ export async function POST(
       where: {
         issueNumber_userId: {
           issueNumber,
-          userId: session.user.id as string,
+          userId: userId,
         },
       },
       create: {
         issueNumber,
-        userId: session.user.id as string,
+        userId: userId,
       },
       update: {},
     });

--- a/src/app/api/feedback/votes/route.ts
+++ b/src/app/api/feedback/votes/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+
+// GET /api/feedback/votes?numbers=1,2,3
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    const userId = (session?.user as { id?: string })?.id || null;
+
+    const { searchParams } = new URL(request.url);
+    const numbersParam = searchParams.get('numbers') || '';
+    const numbers = numbersParam
+      .split(',')
+      .map((n) => parseInt(n.trim(), 10))
+      .filter((n) => !Number.isNaN(n));
+
+    if (numbers.length === 0) {
+      return NextResponse.json({ votes: {} });
+    }
+
+    // Fetch counts per issueNumber
+    const grouped = await db.feedbackVote.groupBy({
+      by: ['issueNumber'],
+      where: { issueNumber: { in: numbers } },
+      _count: { _all: true },
+    });
+
+    const counts: Record<number, number> = {};
+    grouped.forEach((g) => {
+      counts[g.issueNumber] = g._count._all;
+    });
+
+    // Determine which issues the current user voted on
+    let userVotes: Record<number, boolean> = {};
+    if (userId) {
+      const voted = await db.feedbackVote.findMany({
+        where: { userId, issueNumber: { in: numbers } },
+        select: { issueNumber: true },
+      });
+      userVotes = voted.reduce<Record<number, boolean>>((acc, v) => {
+        acc[v.issueNumber] = true;
+        return acc;
+      }, {});
+    }
+
+    // Build map per number
+    const result: Record<number, { count: number; userVoted: boolean }> = {};
+    numbers.forEach((n) => {
+      result[n] = {
+        count: counts[n] || 0,
+        userVoted: Boolean(userVotes[n]),
+      };
+    });
+
+    return NextResponse.json({ votes: result });
+  } catch (error) {
+    console.error('Error fetching feedback votes:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch votes' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -488,7 +488,9 @@ export function FeedbackPageClient() {
                             title={
                               _isClosed
                                 ? 'Voting disabled on closed issues'
-                                : undefined
+                                : alreadyVoted
+                                  ? 'You already voted'
+                                  : undefined
                             }
                             onClick={async () => {
                               if (_isClosed) return;
@@ -537,7 +539,9 @@ export function FeedbackPageClient() {
                             }}
                           >
                             {alreadyVoted
-                              ? 'Voted'
+                              ? `Voted • ${
+                                  internalCount ?? (issue.reactions['+1'] || 0)
+                                }`
                               : (internalCount ?? (issue.reactions['+1'] || 0))}
                           </Button>
                         </Box>

--- a/src/app/feedback/FeedbackPageClient.tsx
+++ b/src/app/feedback/FeedbackPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';
 import {
   Alert,
@@ -479,7 +480,13 @@ export function FeedbackPageClient() {
                           <Button
                             size="small"
                             variant="text"
-                            startIcon={<ThumbUpOffAltIcon fontSize="small" />}
+                            startIcon={
+                              alreadyVoted ? (
+                                <ThumbUpIcon fontSize="small" />
+                              ) : (
+                                <ThumbUpOffAltIcon fontSize="small" />
+                              )
+                            }
                             disabled={
                               Boolean(upvoting[issue.number]) ||
                               _isClosed ||
@@ -488,9 +495,7 @@ export function FeedbackPageClient() {
                             title={
                               _isClosed
                                 ? 'Voting disabled on closed issues'
-                                : alreadyVoted
-                                  ? 'You already voted'
-                                  : undefined
+                                : undefined
                             }
                             onClick={async () => {
                               if (_isClosed) return;
@@ -538,11 +543,7 @@ export function FeedbackPageClient() {
                               }
                             }}
                           >
-                            {alreadyVoted
-                              ? `Voted • ${
-                                  internalCount ?? (issue.reactions['+1'] || 0)
-                                }`
-                              : (internalCount ?? (issue.reactions['+1'] || 0))}
+                            {internalCount ?? (issue.reactions['+1'] || 0)}
                           </Button>
                         </Box>
                         {idx < issues.length - 1 && (


### PR DESCRIPTION
# Feedback: Internal Voting (Per User) + UI Integration

## Summary
This PR adds first-class, per-user feedback voting inside StuffLibrary and wires the Feedback page to use these internal vote counts for sorting and display. We still post a single GitHub +1 reaction for discoverability, but the authoritative count now comes from our database. The result: anyone logged into StuffLibrary can vote once per issue without GitHub OAuth, and the UI reflects votes reliably with immediate feedback.

## Why
- GitHub reactions are per GitHub account. Using a single PAT means only one +1 per issue, regardless of how many app users vote.
- We want wider participation (no GitHub OAuth) and accurate counts for prioritization.
- Internal votes let us keep GitHub issues for tracking while relying on our own tally for sorting and visibility.

## What’s Included
- Database
  - New model `FeedbackVote` (unique per `(issueNumber, userId)`) stored in `feedback_votes`.
  - Migration added (create-only) so reviewers can apply in their environment.
- API
  - `POST /api/feedback/issues/[number]/upvote`
    - Requires an authenticated StuffLibrary session.
    - Upserts the user’s vote for the GitHub issue number.
    - Returns `{ success, internalCount, userVoted }`.
    - Best-effort: posts a single `+1` to the GitHub issue using the PAT for discoverability (no effect on internal counts).
  - `GET /api/feedback/votes?numbers=1,2,3`
    - Returns `{ votes: { [issueNumber]: { count, userVoted } } }` for the current user.
- UI (Feedback page)
  - Loads issues from GitHub, then fetches internal vote counts and voted flags.
  - Sorting:
    - Open issues first, sorted by internal votes (desc), then by created date (desc).
    - Closed issues after open, sorted by closed date (desc).
  - Upvote UX:
    - Button shows outline thumb and total count before voting.
    - On click, shows disabled solid thumb with the same total count (updated immediately from `internalCount`).
    - No optimistic overcounting; errors surface via a snackbar.

## Screens/UX Notes
- The upvote button label always shows the total count.
- After voting, the button is disabled and shows a solid thumbs-up icon.
- Tooltip simplified; no “Voted • N” text or middot.

## Limitations
- GitHub +1 remains best-effort for visibility; it cannot reflect multiple app-user votes due to reaction limits per GitHub account.
- Internal votes currently require a logged-in StuffLibrary session (no anonymous voting).

## Future Enhancements (optional)
- Display both counts (internal vs GitHub) in admin views for analytics.
- Add minimal rate limiting or anti-abuse protections (e.g., per-IP backoff) if needed.
- Allow users to remove their vote (toggle) if we want reversible votes.

## Migration & Deploy
- Apply Prisma migration: `prisma migrate deploy` (or `prisma migrate dev` locally).
- Ensure `GITHUB_TOKEN` remains configured to keep the discoverability +1 behavior.

## QA
1. Sign in and visit `/feedback`.
2. Confirm open issues render above closed; open issues sorted by internal votes desc, then by created date desc.
3. Click upvote on an open issue:
   - Button disables, icon switches to solid thumb, and the count updates immediately.
   - Reload the page — the same count and disabled state persist.
4. Try upvoting again — the button remains disabled. Sign in as a different user and vote — the count increases appropriately.

## Files
- `prisma/schema.prisma`
- `prisma/migrations/20250922173907_feedback_votes/migration.sql`
- `src/app/api/feedback/issues/[number]/upvote/route.ts`
- `src/app/api/feedback/votes/route.ts`
- `src/app/feedback/FeedbackPageClient.tsx`
