### PR TITLE
Audit logs to DB + AI usage logging (OpenAI/Gemini)

### DIFF
--- a/src/lib/ai-pricing.ts
+++ b/src/lib/ai-pricing.ts
@@ -1,0 +1,47 @@
+type PricingKey = `${'openai' | 'gemini'}:${string}`;
+
+const PRICING_CENTS_PER_UNIT: Record<
+  PricingKey,
+  {
+    perTokenIn?: number;
+    perTokenOut?: number;
+    perImageInKB?: number;
+    perImageOutKB?: number;
+  }
+> = {
+  'openai:gpt-4o-mini': { perTokenIn: 0.00015, perTokenOut: 0.0006 },
+  'openai:gpt-4o': { perTokenIn: 0.005, perTokenOut: 0.015 },
+  'gemini:gemini-2.5-flash-image-preview': {
+    perImageInKB: 0.00002,
+    perImageOutKB: 0.00002,
+  },
+  'gemini:gemini-2.5-flash': { perImageInKB: 0.00002, perImageOutKB: 0.00002 },
+};
+
+export function estimateCostCents(args: {
+  provider: 'openai' | 'gemini';
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  inputBytes?: number;
+  outputBytes?: number;
+}): number {
+  const key = `${args.provider}:${args.model}` as PricingKey;
+  const pricing = PRICING_CENTS_PER_UNIT[key];
+  if (!pricing) return 0;
+
+  let cost = 0;
+  if (pricing.perTokenIn && args.inputTokens) {
+    cost += args.inputTokens * pricing.perTokenIn;
+  }
+  if (pricing.perTokenOut && args.outputTokens) {
+    cost += args.outputTokens * pricing.perTokenOut;
+  }
+  if (pricing.perImageInKB && args.inputBytes) {
+    cost += (args.inputBytes / 1024) * pricing.perImageInKB;
+  }
+  if (pricing.perImageOutKB && args.outputBytes) {
+    cost += (args.outputBytes / 1024) * pricing.perImageOutKB;
+  }
+  return Math.round(cost);
+}

--- a/src/lib/ai-usage.ts
+++ b/src/lib/ai-usage.ts
@@ -1,0 +1,50 @@
+import { db } from '@/lib/db';
+
+export type AiUsageLog = {
+  action: 'AI_RENDER';
+  provider: 'openai' | 'gemini';
+  model: string;
+  status: 'ok' | 'error';
+  itemId?: string;
+  userId?: string;
+  latencyMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  inputBytes?: number;
+  outputBytes?: number;
+  costCents?: number;
+  requestId?: string;
+  pricingVersion?: string;
+  errorMessage?: string;
+};
+
+export async function recordAiUsage(log: AiUsageLog): Promise<void> {
+  try {
+    await db.auditLog.create({
+      data: {
+        action: 'AI_RENDER',
+        entityType: 'Item',
+        entityId: log.itemId ?? 'n/a',
+        userId: log.userId ?? null,
+        metadata: {
+          provider: log.provider,
+          model: log.model,
+          status: log.status,
+          cost_cents: log.costCents ?? 0,
+          latency_ms: log.latencyMs ?? null,
+          input_tokens: log.inputTokens ?? null,
+          output_tokens: log.outputTokens ?? null,
+          input_bytes: log.inputBytes ?? null,
+          output_bytes: log.outputBytes ?? null,
+          request_id: log.requestId ?? null,
+          pricing_version: log.pricingVersion ?? 'v1',
+          itemId: log.itemId ?? null,
+          error_message: log.errorMessage ?? null,
+        },
+      },
+    });
+  } catch (e) {
+    // Do not throw; logging failure should not break primary flows
+    console.error('AI usage logging failed', e);
+  }
+}

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -1,4 +1,4 @@
-// import { db } from './db'; // TODO: Enable when audit_logs table is created
+import { db } from './db';
 
 export type AuditAction =
   | 'BORROW_REQUEST_CREATED'
@@ -48,17 +48,18 @@ export async function logAuditEntry({
 
     console.log('📋 AUDIT LOG:', JSON.stringify(auditEntry, null, 2));
 
-    // TODO: Store in database audit_logs table when created
-    // await db.auditLog.create({
-    //   data: {
-    //     action,
-    //     userId,
-    //     entityType,
-    //     entityId,
-    //     details: details ? JSON.stringify(details) : null,
-    //     metadata: metadata ? JSON.stringify(metadata) : null,
-    //   },
-    // });
+    await db.auditLog.create({
+      data: {
+        action,
+        userId,
+        entityType,
+        entityId,
+        details: (details || {}) as any,
+        metadata: (metadata || {}) as any,
+        ipAddress: metadata?.ipAddress ?? null,
+        userAgent: metadata?.userAgent ?? null,
+      },
+    });
   } catch (error) {
     // Don't let audit logging failure affect main operation
     console.error('❌ Failed to log audit entry:', error);


### PR DESCRIPTION
Summary
- Enable DB writes for existing audit events (audit_logs).
- Add reusable AI usage logger + pricing helper.
- Wire OpenAI chat completions (borrow script, classify) with latency/tokens/cost logging.
- Wire Gemini watercolor generation with latency/bytes/estimated cost logging.

Details
- File: src/lib/audit-log.ts — now writes to Prisma audit_logs (keeps console logs).
- File: src/lib/ai-usage.ts — recordAiUsage(AI_RENDER) writes provider/model/usage/cost.
- File: src/lib/ai-pricing.ts — estimateCostCents() via simple model map (env-tunable later).
- File: src/lib/ai.ts — wraps OpenAI calls to record usage on success/error.
- File: src/lib/watercolor-service.ts — logs Gemini usage around image generation.

Why
- Populate admin /costs and audit dashboards with accurate AI usage and costs.
- Keep core flows resilient; logging failures do not affect user operations.

Verification
1) OpenAI text: Generate Borrow Script (or classify image).
   - Check audit_logs for action='AI_RENDER', provider='openai', model='gpt-4o-mini'.
   - Verify latency_ms, input_tokens, output_tokens, cost_cents.
2) Gemini image: Trigger watercolor render.
   - Check audit_logs for provider='gemini', model='gemini-2.5-flash-image-preview'.
   - Verify latency_ms, input_bytes/output_bytes, cost_cents.
3) Error path: Temporarily break an API key.
   - Confirm audit_logs contains status='error' entries with error_message.

Notes
- No schema changes; uses existing audit_logs JSON metadata.
- exactOptionalPropertyTypes respected; only logs defined fields.
- Pricing map is approximate and easy to update.

Follow-ups (optional)
- Expand pricing map and make it env-configurable.
- Add admin UI (/costs) aggregations by day/provider/model.
- Consider sampling/limits in high-throughput paths to keep logs concise.