### PR TITLE
Filter UI to active users/items via API (collections endpoints)

### DIFF
--- a/src/app/api/collections/[id]/members/route.ts
+++ b/src/app/api/collections/[id]/members/route.ts
@@ -47,6 +47,7 @@ export async function GET(
       where: {
         collectionId,
         isActive: true,
+        user: { status: 'active' },
       },
       include: {
         user: {
@@ -55,6 +56,7 @@ export async function GET(
             name: true,
             email: true,
             image: true,
+            status: true,
             addresses: {
               where: { isActive: true },
               take: 1,
@@ -85,6 +87,7 @@ export async function GET(
             name: true,
             email: true,
             image: true,
+            status: true,
             addresses: {
               where: { isActive: true },
               take: 1,
@@ -102,8 +105,8 @@ export async function GET(
     });
 
     const allMembers = [
-      // Owner
-      ...(collection?.owner
+      // Owner (only if active)
+      ...(collection?.owner && collection.owner.status === 'active'
         ? [
             {
               id: `owner-${collection.owner.id}`,

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -26,6 +26,7 @@ export async function GET(
             id: true,
             name: true,
             image: true,
+            status: true,
             addresses: {
               where: { isActive: true },
               select: {
@@ -41,13 +42,14 @@ export async function GET(
           },
         },
         members: {
-          where: { isActive: true },
+          where: { isActive: true, user: { status: 'active' } },
           include: {
             user: {
               select: {
                 id: true,
                 name: true,
                 image: true,
+                status: true,
                 email: true,
                 addresses: {
                   where: { isActive: true },
@@ -112,6 +114,7 @@ export async function GET(
           },
         },
         active: true, // Only show active items
+        owner: { status: 'active' },
         ...(includeUnillustrated
           ? {}
           : {
@@ -178,7 +181,8 @@ export async function GET(
       updatedAt: library.updatedAt,
       owner: library.owner,
       userRole: effectiveRole,
-      memberCount: library._count.members + 1, // +1 for owner
+      memberCount:
+        library.members.length + (library.owner.status === 'active' ? 1 : 0),
       itemCount: items.length,
       inviteRateLimitPerHour: (library as any).inviteRateLimitPerHour ?? 0,
       members: [


### PR DESCRIPTION
# Filter UI to active users/items via API (collections endpoints)

## Summary
Centralize active-only filtering in the API so the frontend automatically shows only active users and items.

## Changes
- `GET /api/collections/:id`
  - Members: only active memberships where `user.status === 'active'`.
  - Items: only items whose `owner.status === 'active'`.
  - `memberCount`: computed from filtered members + owner if active.
- `GET /api/collections/:id/members`
  - Returns only active users; includes owner only if active.

## Why
Admin console now supports setting users inactive. To avoid UI fan‑out and inconsistencies, filtering at the API layer ensures all screens and counts reflect only active users and their items.

## Notes
- No schema changes.
- Typecheck passes locally.

## Verification
- Open a collection you know has inactive users.
  - Members list excludes inactive users.
  - Owner appears only if their status is active.
  - Items list excludes items from inactive owners.
  - Member count reflects the filtered list + active owner.

## Follow-ups (optional)
- Apply the same active-user filter to discovery and admin listing endpoints for fully consistent counts across dashboards.
