### PR TITLE
Guest-pass invites: auto-join for logged-in users + banner CTA

### DIFF
--- a/src/app/api/collections/[id]/join/route.ts
+++ b/src/app/api/collections/[id]/join/route.ts
@@ -159,13 +159,17 @@ export async function POST(
       owner: updatedCollection!.owner,
     };
 
-    return NextResponse.json(
+    const res = NextResponse.json(
       {
         message: 'Successfully joined collection',
         collection: formattedCollection,
       },
       { status: 201 }
     );
+    // Clear invite cookies after join
+    res.cookies.set('invite_token', '', { path: '/', maxAge: 0 });
+    res.cookies.set('invite_library', '', { path: '/', maxAge: 0 });
+    return res;
   } catch (error) {
     console.error('Error joining collection:', error);
     return NextResponse.json(

--- a/src/app/api/collections/[id]/join/route.ts
+++ b/src/app/api/collections/[id]/join/route.ts
@@ -52,9 +52,24 @@ export async function POST(
       );
     }
 
-    // For now, only allow joining public collections
-    // TODO: Add invitation system for private collections
-    if (!collection.isPublic) {
+    // Allow join if collection is public OR a valid invite cookie is present
+    const inviteToken = request.cookies.get('invite_token')?.value;
+    const inviteLibrary = request.cookies.get('invite_library')?.value;
+    let inviteOk = false;
+    if (inviteToken && inviteLibrary === collectionId) {
+      const inv = await db.invitation.findFirst({
+        where: {
+          token: inviteToken,
+          libraryId: collectionId,
+          type: 'library',
+          status: { in: ['PENDING', 'SENT'] },
+          expiresAt: { gt: new Date() },
+        },
+        select: { id: true },
+      });
+      inviteOk = !!inv;
+    }
+    if (!collection.isPublic && !inviteOk) {
       return NextResponse.json(
         { error: 'This collection is private and requires an invitation' },
         { status: 403 }
@@ -95,6 +110,18 @@ export async function POST(
           collectionId,
           role: 'member',
           isActive: true,
+        },
+      });
+    }
+
+    // If joined via invite cookie, mark invitation accepted
+    if (inviteOk && inviteToken) {
+      await db.invitation.updateMany({
+        where: { token: inviteToken, libraryId: collectionId },
+        data: {
+          status: 'ACCEPTED',
+          acceptedAt: new Date(),
+          receiverId: userId,
         },
       });
     }

--- a/src/app/api/invitations/[token]/details/route.ts
+++ b/src/app/api/invitations/[token]/details/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     const invitation = await db.invitation.findFirst({
       where: {
         token,
-        type: 'collection',
+        type: 'library',
         status: { in: ['PENDING', 'SENT'] },
       },
       include: {

--- a/src/app/invite/[token]/route.ts
+++ b/src/app/invite/[token]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { db } from '@/lib/db';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+  try {
+    if (!token || typeof token !== 'string') {
+      return NextResponse.redirect(new URL('/?invite=invalid', request.url));
+    }
+
+    const invitation = await db.invitation.findFirst({
+      where: {
+        token,
+        type: 'library',
+        status: { in: ['PENDING', 'SENT'] },
+      },
+      select: {
+        libraryId: true,
+        expiresAt: true,
+      },
+    });
+
+    if (!invitation) {
+      return NextResponse.redirect(new URL('/?invite=invalid', request.url));
+    }
+
+    if (new Date() > invitation.expiresAt) {
+      return NextResponse.redirect(new URL('/?invite=expired', request.url));
+    }
+
+    const target = new URL(
+      `/collection/${invitation.libraryId}?guest=1`,
+      request.url
+    );
+    const res = NextResponse.redirect(target);
+    // Set short-lived cookies (e.g., 7 days or until user closes browser)
+    res.cookies.set('invite_token', token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+    });
+    res.cookies.set('invite_library', invitation.libraryId!, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7,
+    });
+    return res;
+  } catch {
+    return NextResponse.redirect(new URL('/?invite=error', request.url));
+  }
+}

--- a/src/app/invite/[token]/route.ts
+++ b/src/app/invite/[token]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
 
+import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
 
 export async function GET(
@@ -32,17 +34,61 @@ export async function GET(
       return NextResponse.redirect(new URL('/?invite=expired', request.url));
     }
 
+    // If session exists, auto-join and accept invite
+    const session = await getServerSession(authOptions);
+    if (session?.user) {
+      const userId = (session.user as any).id;
+      if (userId) {
+        const libId = invitation.libraryId!;
+        const existing = await db.collectionMember.findUnique({
+          where: { userId_collectionId: { userId, collectionId: libId } },
+          select: { id: true, isActive: true },
+        });
+        if (!existing) {
+          await db.collectionMember.create({
+            data: {
+              userId,
+              collectionId: libId,
+              role: 'member',
+              isActive: true,
+            },
+          });
+        } else if (!existing.isActive) {
+          await db.collectionMember.update({
+            where: { id: existing.id },
+            data: { isActive: true },
+          });
+        }
+        await db.invitation.updateMany({
+          where: { token, libraryId: libId },
+          data: {
+            status: 'ACCEPTED',
+            acceptedAt: new Date(),
+            receiverId: userId,
+          },
+        });
+        const redirect = new URL(
+          `/collection/${libId}?message=joined_successfully`,
+          request.url
+        );
+        const response = NextResponse.redirect(redirect);
+        response.cookies.set('invite_token', '', { path: '/', maxAge: 0 });
+        response.cookies.set('invite_library', '', { path: '/', maxAge: 0 });
+        return response;
+      }
+    }
+
+    // Not logged in: set guest cookies and redirect
     const target = new URL(
       `/collection/${invitation.libraryId}?guest=1`,
       request.url
     );
     const res = NextResponse.redirect(target);
-    // Set short-lived cookies (e.g., 7 days or until user closes browser)
     res.cookies.set('invite_token', token, {
       httpOnly: true,
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
+      maxAge: 60 * 60 * 24 * 7,
     });
     res.cookies.set('invite_library', invitation.libraryId!, {
       httpOnly: true,


### PR DESCRIPTION
# Guest-pass invites: auto-join for logged-in users + banner CTA

## Summary
- `/invite/[token]`: if session exists and invite is valid, auto-join and accept the invite; otherwise set guest cookies and redirect to collection.
- `GET /api/collections/:id`: respects guest cookies for read-only access.
- `POST /api/collections/:id/join`: accepts invite cookie for private libraries; clears cookies after join.
- Collection page: show a “viewing as guest” banner with Join button that signs in if needed, then joins.

## Why
- Reduce friction for invitees: logged-in users are joined immediately; logged-out users see the library instantly and can join with one click.
- Avoids messy duplicate “guest accounts” by keeping guest as cookie-only state.

## Files
- `src/app/invite/[token]/route.ts`
- `src/app/api/collections/[id]/route.ts`
- `src/app/api/collections/[id]/join/route.ts`
- `src/components/CollectionDetailClient.tsx`

## Verification
1. Logged-in: Click invite link → redirect to library; role is member, invite marked ACCEPTED.
2. Logged-out: Click invite link → redirected to library with guest banner; Join triggers signin if needed then joins; invite cookies cleared.
3. Private libraries: join works with valid invite cookie; otherwise rejected.

## Follow-ups (optional)
- Clear invite cookies on initial load if user is already a member.
- Add toast on join success instead of reload.
- Track guest→join conversion metric.
