### PR TITLE
Fix library card member counts to exclude inactive users

### DIFF
--- a/src/app/api/admin/collections/route.ts
+++ b/src/app/api/admin/collections/route.ts
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
         },
         _count: {
           select: {
-            members: true,
+            members: { where: { isActive: true } },
             items: true,
             invitations: true,
           },

--- a/src/app/api/collections/[id]/join/route.ts
+++ b/src/app/api/collections/[id]/join/route.ts
@@ -182,7 +182,7 @@ export async function POST(
         },
         _count: {
           select: {
-            members: true,
+            members: { where: { isActive: true } },
             items: true,
           },
         },

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -88,7 +88,7 @@ export async function GET(
         },
         _count: {
           select: {
-            members: true,
+            members: { where: { isActive: true } },
           },
         },
       },
@@ -438,7 +438,7 @@ export async function PUT(
         },
         _count: {
           select: {
-            members: true,
+            members: { where: { isActive: true } },
             items: {
               where: {
                 item: { currentBorrowRequestId: null },
@@ -505,7 +505,7 @@ export async function DELETE(
         _count: {
           select: {
             items: true,
-            members: true,
+            members: { where: { isActive: true } },
           },
         },
       },

--- a/src/app/api/collections/discover/route.ts
+++ b/src/app/api/collections/discover/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
         },
         _count: {
           select: {
-            members: true,
+            members: { where: { isActive: true } },
             items: {
               where: {
                 item: { currentBorrowRequestId: null },

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -82,7 +82,7 @@ export async function GET() {
         },
         _count: {
           select: {
-            members: true,
+            members: { where: { isActive: true } },
             items: { where: { item: { currentBorrowRequestId: null } } },
           },
         },
@@ -115,7 +115,7 @@ export async function GET() {
             },
             _count: {
               select: {
-                members: true,
+                members: { where: { isActive: true } },
                 items: { where: { item: { currentBorrowRequestId: null } } },
               },
             },


### PR DESCRIPTION
## Summary

Library cards on the stacks page were displaying inflated member counts by including inactive users in the totals. This PR fixes the issue by updating all API endpoints to filter `_count.members` queries for active users only (`{ isActive: true }`).

### Problem

The `_count.members` queries across multiple API endpoints were counting all members regardless of their `isActive` status, leading to incorrect member count displays on library cards. This created confusion as the displayed counts didn't match the actual active membership.

### Solution

Updated the following API endpoints to filter member counts for active users only:

#### Fixed Files:
- **`src/app/api/collections/route.ts`**
  - Fixed owned collections query (line 85)
  - Fixed memberships query (line 118)
- **`src/app/api/collections/discover/route.ts`**
  - Fixed discovery endpoint member counting (line 101)
- **`src/app/api/collections/[id]/join/route.ts`**
  - Fixed join endpoint response member counting (line 185)
- **`src/app/api/collections/[id]/route.ts`**
  - Fixed GET endpoint member counting (line 91)
  - Fixed PUT endpoint member counting (line 441)
  - Fixed DELETE endpoint member counting (line 508)
- **`src/app/api/admin/collections/route.ts`**
  - Fixed admin endpoint member counting (line 66)

#### Key Change Pattern:
```typescript
// Before
_count: {
  select: {
    members: true,
  },
}

// After
_count: {
  select: {
    members: { where: { isActive: true } },
  },
}
```

### Testing

- ✅ Build completes successfully without errors
- ✅ All modified queries maintain proper filtering logic
- ✅ No breaking changes to existing API contracts

### Impact

- Library cards now display accurate member counts excluding inactive users
- Consistent member counting across all API endpoints
- Better user experience with truthful membership information

🤖 Generated with [Claude Code](https://claude.ai/code)