### PR TITLE
Fix member count consistency with user status filtering

### DIFF
--- a/src/app/api/admin/collections/route.ts
+++ b/src/app/api/admin/collections/route.ts
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: true,
             invitations: true,
           },

--- a/src/app/api/collections/[id]/join/route.ts
+++ b/src/app/api/collections/[id]/join/route.ts
@@ -182,7 +182,7 @@ export async function POST(
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: true,
           },
         },

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -88,7 +88,7 @@ export async function GET(
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
           },
         },
       },
@@ -438,7 +438,7 @@ export async function PUT(
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: {
               where: {
                 item: { currentBorrowRequestId: null },
@@ -505,7 +505,7 @@ export async function DELETE(
         _count: {
           select: {
             items: true,
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
           },
         },
       },

--- a/src/app/api/collections/discover/route.ts
+++ b/src/app/api/collections/discover/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: {
               where: {
                 item: { currentBorrowRequestId: null },

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -82,7 +82,7 @@ export async function GET() {
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: { where: { item: { currentBorrowRequestId: null } } },
           },
         },
@@ -115,7 +115,9 @@ export async function GET() {
             },
             _count: {
               select: {
-                members: { where: { isActive: true } },
+                members: {
+                  where: { isActive: true, user: { status: 'active' } },
+                },
                 items: { where: { item: { currentBorrowRequestId: null } } },
               },
             },


### PR DESCRIPTION
## Summary

This PR resolves the root cause of member count double-counting by ensuring consistency between `members` relation queries and `_count.members` queries across all API endpoints.

### Problem

After investigating the "libraries showing twice as many members" issue, I discovered an inconsistency in filtering logic:

- **`members` relation queries**: Correctly filtered by `{ isActive: true, user: { status: 'active' } }`
- **`_count.members` queries**: Only filtered by `{ isActive: true }` (missing user status filter)

This caused discrepancies when active CollectionMember records existed for users with inactive accounts, resulting in different counts between the two approaches and inflated member counts on library cards.

### Solution

Updated all `_count.members` queries to match the filtering criteria used in `members` relations:

#### Before
```typescript
_count: {
  select: {
    members: { where: { isActive: true } }
  }
}
```

#### After  
```typescript
_count: {
  select: {
    members: { where: { isActive: true, user: { status: 'active' } } }
  }
}
```

### Fixed Files

- **`src/app/api/collections/route.ts`** - Main collections endpoint (both owned and memberships)
- **`src/app/api/collections/discover/route.ts`** - Discovery endpoint  
- **`src/app/api/collections/[id]/join/route.ts`** - Join endpoint
- **`src/app/api/collections/[id]/route.ts`** - Individual collection endpoint (all 3 _count queries)
- **`src/app/api/admin/collections/route.ts`** - Admin collections endpoint

### Testing

- ✅ Build completes successfully without errors
- ✅ All `_count.members` queries now use consistent filtering logic
- ✅ No breaking changes to existing API contracts

### Impact

- **Library cards** now show accurate member counts excluding both inactive members AND members with inactive user accounts
- **Consistent behavior** across all API endpoints that return member counts  
- **Eliminates double-counting** - member counts calculated using unified criteria
- **Resolves** the specific issue where libraries were showing "twice as many members"

This ensures member count accuracy throughout the application and provides truthful membership information to users.

🤖 Generated with [Claude Code](https://claude.ai/code)