### PR TITLE
Fix: library card member counts exclude inactive users

### DIFF
--- a/src/app/api/admin/collections/route.ts
+++ b/src/app/api/admin/collections/route.ts
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: true,
             invitations: true,
           },

--- a/src/app/api/collections/[id]/join/route.ts
+++ b/src/app/api/collections/[id]/join/route.ts
@@ -182,7 +182,7 @@ export async function POST(
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: true,
           },
         },

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -88,7 +88,7 @@ export async function GET(
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
           },
         },
       },
@@ -438,7 +438,7 @@ export async function PUT(
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: {
               where: {
                 item: { currentBorrowRequestId: null },
@@ -505,7 +505,7 @@ export async function DELETE(
         _count: {
           select: {
             items: true,
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
           },
         },
       },

--- a/src/app/api/collections/discover/route.ts
+++ b/src/app/api/collections/discover/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: {
               where: {
                 item: { currentBorrowRequestId: null },

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -82,7 +82,7 @@ export async function GET() {
         },
         _count: {
           select: {
-            members: { where: { isActive: true } },
+            members: { where: { isActive: true, user: { status: 'active' } } },
             items: { where: { item: { currentBorrowRequestId: null } } },
           },
         },
@@ -115,7 +115,9 @@ export async function GET() {
             },
             _count: {
               select: {
-                members: { where: { isActive: true } },
+                members: {
+                  where: { isActive: true, user: { status: 'active' } },
+                },
                 items: { where: { item: { currentBorrowRequestId: null } } },
               },
             },


### PR DESCRIPTION
## Summary

Align library member counts across API endpoints to include only active users. This fixes inflated counts on library cards and collection views.

## Changes
- Filter members with  and  where counts are calculated.
- Ensure consistency in:
  - 
  - 
  - 
  - Admin collections listing
  - Join flow response metadata

## Why
Member counts previously included inactive users, leading to confusing totals on the library card and detail pages.

## Impact
- Displayed member counts now reflect active members only.
- No schema changes; purely query-level adjustments.

## Test Plan
- Create a collection with N members and deactivate one user membership; verify count decrements.
- Compare counts between library cards, discover list, and collection detail — they should match.
