### PR TITLE
Fix invite join flow: route via /auth/callback and returnTo after profile

### DIFF
--- a/src/app/profile/create/ProfileCreationHandler.tsx
+++ b/src/app/profile/create/ProfileCreationHandler.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import {
@@ -33,6 +33,7 @@ export function ProfileCreationHandler({
   const [loadingUser, setLoadingUser] = useState(false);
   const [userId, setUserId] = useState<string | undefined>(userIdProp);
   const [user, setUser] = useState<typeof userProp>(userProp);
+  const searchParams = useSearchParams();
 
   // Ensure we have the current user and id; redirect if unauthorized
   useEffect(() => {
@@ -135,8 +136,18 @@ export function ProfileCreationHandler({
       // Clear any draft data
       localStorage.removeItem('profile-wizard-draft');
 
-      // Redirect to lobby with welcome message
-      router.push('/stacks?welcome=true');
+      // Redirect to intended destination if provided, otherwise to lobby
+      const returnTo = searchParams?.get('returnTo');
+      if (returnTo) {
+        try {
+          const decoded = decodeURIComponent(returnTo);
+          router.push(decoded);
+        } catch {
+          router.push('/stacks?welcome=true');
+        }
+      } else {
+        router.push('/stacks?welcome=true');
+      }
       router.refresh(); // Refresh to update session data
     } catch (error) {
       alert(

--- a/src/components/CollectionDetailClient.tsx
+++ b/src/components/CollectionDetailClient.tsx
@@ -402,8 +402,10 @@ export function CollectionDetailClient({
             storedInviteToken
           );
         }
-        const returnTo = encodeURIComponent(`/collection/${collectionId}`);
-        window.location.href = `/api/auth/signin?callbackUrl=${returnTo}`;
+        // Always route through our smart auth callback so invite consumption
+        // and profile completion logic can run before landing on the library
+        const callback = encodeURIComponent('/auth/callback');
+        window.location.href = `/auth/signin?callbackUrl=${callback}`;
       } else {
         const data = await res.json().catch(() => ({}));
         console.error('[CollectionDetailClient] join failed', {


### PR DESCRIPTION
## Summary
Fixes the invite/member onboarding so invited guests who click "Join now" are routed through , which consumes invite cookies server-side, creates/reactivates membership, enforces profile completion, and then lands them back in the invited library as a member.

## Root Cause
We were bypassing our  logic by sending unauthenticated users to  with a  pointing directly to the library (e.g. ). As a result:
- Invite cookies (, ) were never consumed server-side, so no membership was created.
- Profile completion wasn’t enforced, so the user landed back in the library as a guest.

## What Changed
- Collection join redirect (unauthenticated):
  -  now sends users to .
  - Guarantees  runs and calls , which:
    - Validates invite cookies
    - Creates/reactivates 
    - Marks invitation  and clears cookies
    - Returns a redirect to 
  - If the profile is incomplete,  now redirects to .

- Post-profile completion redirect:
  -  now reads  and navigates back to the originally intended destination after profile creation.
  - Falls back to  if  is missing or invalid.

## Files Touched
- 
  - On 401 from , redirect via: .
- 
  - After successful profile creation, honor  query param; otherwise go to .

## Resulting Flow
1. Guest opens invite link → sees library in guest mode.
2. Clicks "Join now" → email auth → .
3.  consumes invite cookies via  and creates membership.
4. If profile incomplete → .
5. After profile creation → redirect to , now as a member.

## Safety / Risks
- Changes are scoped to the auth/join flow and profile completion routing.
- Existing members or owners are unaffected.
- If cookies are missing/invalid, the legacy/normal flows still apply (they land in  or ).

## Manual Verification Steps
- Open invite link in incognito → guest preview.
- Click "Join now" → sign in with email code.
- Observe server logs:
  - 
  - 
  -  or 
  - 
  - 
- If profile incomplete → redirected to .
- Complete profile → land at  with member UI (no guest banner).

## Additional Notes
- Retains the fallback localStorage invite-token use in  for robustness.
- No DB schema changes.

## Screenshots / Logs
N/A (server logs noted above).